### PR TITLE
Highlight the content of fenced code blocks with specified language in that language.

### DIFF
--- a/plugin/mkd.vim
+++ b/plugin/mkd.vim
@@ -1,5 +1,5 @@
 " Heavily based on vim-notes - http://peterodding.com/code/vim/notes/
-function! s:Markdown_highlight_sources()
+function! s:Markdown_highlight_sources(force)
     " Syntax highlight source code embedded in notes.
     " Look for code blocks in the current file
     let filetypes = {}
@@ -10,7 +10,7 @@ function! s:Markdown_highlight_sources()
     if !exists('b:mkd_known_filetypes')
         let b:mkd_known_filetypes = {}
     endif
-    if b:mkd_known_filetypes == filetypes || empty(filetypes)
+    if !a:force && (b:mkd_known_filetypes == filetypes || empty(filetypes))
         return
     endif
 
@@ -18,7 +18,7 @@ function! s:Markdown_highlight_sources()
     let startgroup = 'mkdCodeStart'
     let endgroup = 'mkdCodeEnd'
     for ft in keys(filetypes)
-        if !has_key(b:mkd_known_filetypes, ft)
+        if a:force || !has_key(b:mkd_known_filetypes, ft)
 
             let group = 'mkdSnippet' . toupper(ft)
             let include = s:syntax_include(ft)
@@ -56,16 +56,16 @@ function! s:syntax_include(filetype)
 endfunction
 
 
-function! s:Markdown_refresh_syntax()
+function! s:Markdown_refresh_syntax(force)
     if &filetype == 'mkd' && line('$') > 1
-        call s:Markdown_highlight_sources()
+        call s:Markdown_highlight_sources(a:force)
     endif
 endfunction
 
 augroup Mkd
     autocmd!
-    au BufReadPost * call s:Markdown_refresh_syntax()
-    au BufReadPost,BufWritePost * call s:Markdown_refresh_syntax()
-    au InsertEnter,InsertLeave * call s:Markdown_refresh_syntax()
-    au CursorHold,CursorHoldI * call s:Markdown_refresh_syntax()
+    au BufReadPost * call s:Markdown_refresh_syntax(1)
+    au BufWritePost * call s:Markdown_refresh_syntax(0)
+    au InsertEnter,InsertLeave * call s:Markdown_refresh_syntax(0)
+    au CursorHold,CursorHoldI * call s:Markdown_refresh_syntax(0)
 augroup END

--- a/plugin/mkd.vim
+++ b/plugin/mkd.vim
@@ -22,7 +22,7 @@ function! s:Markdown_highlight_sources()
 
             let group = 'mkdSnippet' . toupper(ft)
             let include = s:syntax_include(ft)
-            let command = 'syntax region %s matchgroup=%s start="```%s" matchgroup=%s end="```" keepend contains=%s%s'
+            let command = 'syntax region %s matchgroup=%s start="```%s$" matchgroup=%s end="```" keepend contains=%s%s'
             execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') ? ' concealends' : '')
             execute printf('syntax cluster mkdNonListItem add=%s', group)
 

--- a/plugin/mkd.vim
+++ b/plugin/mkd.vim
@@ -1,30 +1,34 @@
-" Completely stolen from vim-notes - http://peterodding.com/code/vim/notes/
-function! s:Markdown_highlight_sources(force)
+" Heavily based on vim-notes - http://peterodding.com/code/vim/notes/
+function! s:Markdown_highlight_sources()
     " Syntax highlight source code embedded in notes.
     " Look for code blocks in the current file
     let filetypes = {}
     for line in getline(1, '$')
-        let ft = matchstr(line, '```\zs\w\+\>')
-        if ft !~ '^\d*$' | let filetypes[ft] = 1 | endif
+        let ft = matchstr(line, '```\zs\w*\>')
+        if !empty(ft) && ft !~ '^\d*$' | let filetypes[ft] = 1 | endif
     endfor
-    " Don't refresh the highlighting if nothing has changed.
-    if !a:force && exists('b:mkd_previous_sources') && b:mkd_previous_sources == filetypes
-        return
-    else
-        let b:mkd_previous_sources = filetypes
+    if !exists('b:mkd_known_filetypes')
+        let b:mkd_known_filetypes = {}
     endif
+    if b:mkd_known_filetypes == filetypes || empty(filetypes)
+        return
+    endif
+
     " Now we're ready to actually highlight the code blocks.
-    if !empty(filetypes)
-        let startgroup = 'mkdCodeStart'
-        let endgroup = 'mkdCodeEnd'
-        for ft in keys(filetypes)
+    let startgroup = 'mkdCodeStart'
+    let endgroup = 'mkdCodeEnd'
+    for ft in keys(filetypes)
+        if !has_key(b:mkd_known_filetypes, ft)
+
             let group = 'mkdSnippet' . toupper(ft)
             let include = s:syntax_include(ft)
-            let command = 'syntax region %s matchgroup=%s start="^```%s$" matchgroup=%s end="^```$" keepend contains=%s%s'
+            let command = 'syntax region %s matchgroup=%s start="```%s" matchgroup=%s end="```" keepend contains=%s%s'
             execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') ? ' concealends' : '')
             execute printf('syntax cluster mkdNonListItem add=%s', group)
-        endfor
-    endif
+
+            let b:mkd_known_filetypes[ft] = 1
+        endif
+    endfor
 endfunction
 
 function! s:syntax_include(filetype)
@@ -54,7 +58,7 @@ endfunction
 
 function! s:Markdown_refresh_syntax()
     if &filetype == 'mkd' && line('$') > 1
-        call s:Markdown_highlight_sources(0)
+        call s:Markdown_highlight_sources()
     endif
 endfunction
 
@@ -65,4 +69,3 @@ augroup Mkd
     au InsertEnter,InsertLeave * call s:Markdown_refresh_syntax()
     au CursorHold,CursorHoldI * call s:Markdown_refresh_syntax()
 augroup END
-

--- a/plugin/mkd.vim
+++ b/plugin/mkd.vim
@@ -1,0 +1,68 @@
+" Completely stolen from vim-notes - http://peterodding.com/code/vim/notes/
+function! s:Markdown_highlight_sources(force)
+    " Syntax highlight source code embedded in notes.
+    " Look for code blocks in the current file
+    let filetypes = {}
+    for line in getline(1, '$')
+        let ft = matchstr(line, '```\zs\w\+\>')
+        if ft !~ '^\d*$' | let filetypes[ft] = 1 | endif
+    endfor
+    " Don't refresh the highlighting if nothing has changed.
+    if !a:force && exists('b:mkd_previous_sources') && b:mkd_previous_sources == filetypes
+        return
+    else
+        let b:mkd_previous_sources = filetypes
+    endif
+    " Now we're ready to actually highlight the code blocks.
+    if !empty(filetypes)
+        let startgroup = 'mkdCodeStart'
+        let endgroup = 'mkdCodeEnd'
+        for ft in keys(filetypes)
+            let group = 'mkdSnippet' . toupper(ft)
+            let include = s:syntax_include(ft)
+            let command = 'syntax region %s matchgroup=%s start="^```%s$" matchgroup=%s end="^```$" keepend contains=%s%s'
+            execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') ? ' concealends' : '')
+            execute printf('syntax cluster mkdNonListItem add=%s', group)
+        endfor
+    endif
+endfunction
+
+function! s:syntax_include(filetype)
+    " Include the syntax highlighting of another {filetype}.
+    let grouplistname = '@' . toupper(a:filetype)
+    " Unset the name of the current syntax while including the other syntax
+    " because some syntax scripts do nothing when "b:current_syntax" is set
+    if exists('b:current_syntax')
+        let syntax_save = b:current_syntax
+        unlet b:current_syntax
+    endif
+    try
+        execute 'syntax include' grouplistname 'syntax/' . a:filetype . '.vim'
+        execute 'syntax include' grouplistname 'after/syntax/' . a:filetype . '.vim'
+    catch /E484/
+        " Ignore missing scripts
+    endtry
+    " Restore the name of the current syntax
+    if exists('syntax_save')
+        let b:current_syntax = syntax_save
+    elseif exists('b:current_syntax')
+        unlet b:current_syntax
+    endif
+    return grouplistname
+endfunction
+
+
+function! s:Markdown_refresh_syntax()
+    if &filetype == 'mkd' && line('$') > 1
+        call s:Markdown_highlight_sources(0)
+    endif
+endfunction
+
+augroup Mkd
+    autocmd!
+    au BufReadPost * call s:Markdown_refresh_syntax()
+    au BufReadPost,BufWritePost * call s:Markdown_refresh_syntax()
+    au InsertEnter,InsertLeave * call s:Markdown_refresh_syntax()
+    au CursorHold,CursorHoldI * call s:Markdown_refresh_syntax()
+augroup END
+

--- a/plugin/mkd.vim
+++ b/plugin/mkd.vim
@@ -22,7 +22,7 @@ function! s:Markdown_highlight_sources()
 
             let group = 'mkdSnippet' . toupper(ft)
             let include = s:syntax_include(ft)
-            let command = 'syntax region %s matchgroup=%s start="```%s$" matchgroup=%s end="```" keepend contains=%s%s'
+            let command = 'syntax region %s matchgroup=%s start="^\s*```%s$" matchgroup=%s end="\s*```$" keepend contains=%s%s'
             execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') ? ' concealends' : '')
             execute printf('syntax cluster mkdNonListItem add=%s', group)
 

--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -70,6 +70,8 @@ syn region mkdBlockquote   start=/^\s*>/                   end=/$/ contains=mkdL
 syn region mkdCode         start=/\(\([^\\]\|^\)\\\)\@<!`/ end=/\(\([^\\]\|^\)\\\)\@<!`/
 syn region mkdCode         start=/\s*``[^`]*/              end=/[^`]*``\s*/
 syn region mkdCode         start=/^\s*```\s*[0-9A-Za-z_-]*\s*$/          end=/^\s*```\s*$/
+syn match  mkdCodeStart    /^```\w*$/
+syn match  mkdCodeEnd      /^```$/
 syn region mkdCode         start="<pre[^>]*>"              end="</pre>"
 syn region mkdCode         start="<code[^>]*>"             end="</code>"
 syn region mkdFootnote     start="\[^"                     end="\]"
@@ -94,7 +96,7 @@ syn region htmlH6       start="^\s*######"              end="\($\|#\+\)" contain
 syn match  htmlH1       /^.\+\n=\+$/ contains=@Spell
 syn match  htmlH2       /^.\+\n-\+$/ contains=@Spell
 
-syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdID,mkdURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6
+syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdID,mkdURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdCodeStart,mkdCodeEnd
 
 "highlighting for Markdown groups
 HtmlHiLink mkdString	    String


### PR DESCRIPTION
Based on the code from [vim-notes](http://peterodding.com/code/vim/notes/), adds syntax highlighting for GFM code blocks. E.g.

    ```vim
    let g:foo = 1
    ```

is shown as syntax highlighted with the vim syntax highlighting.

This introduces a `plugin/mkd.vim` file. Putting this code in `ftplugin` meant that it didn't refresh the syntax on `BufReadPost`. 

As per `contributing.md`:
* It can be tested with `test\syntax.md`, you'll see the ruby block is highlighted.
* `readme.md` hasn't been updated, as it doesn't require any configuration