### PR TITLE
fixed issues with \<pre\>, \<code\> and certain things following ```

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -69,9 +69,9 @@ syn match  mkdLineBreak    /  \+$/
 syn region mkdBlockquote   start=/^\s*>/                   end=/$/ contains=mkdLineBreak,mkdLineContinue,@Spell
 syn region mkdCode         start=/\(\([^\\]\|^\)\\\)\@<!`/ end=/\(\([^\\]\|^\)\\\)\@<!`/
 syn region mkdCode         start=/\s*``[^`]*/              end=/[^`]*``\s*/
-syn region mkdCode         start=/^\s*```\s*[0-9A-Za-z_-]*\s*$/          end=/^\s*```\s*$/
-syn region mkdCode         start="<pre[^>]*>"              end="</pre>"
-syn region mkdCode         start="<code[^>]*>"             end="</code>"
+syn region mkdCode         start=/^\s*```.*$/              end=/^\s*```\s*$/
+syn region mkdCode         start="<pre[^>\\]*>"            end="</pre>"
+syn region mkdCode         start="<code[^>\\]*>"           end="</code>"
 syn region mkdFootnote     start="\[^"                     end="\]"
 syn match  mkdCode         /^\s*\n\(\(\s\{8,}[^ ]\|\t\t\+[^\t]\).*\n\)\+/
 syn match  mkdIndentCode   /^\s*\n\(\(\s\{4,}[^ ]\|\t\+[^\t]\).*\n\)\+/ contained

--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -49,8 +49,9 @@ syn region htmlBoldItalic start="\S\@<=___\|___\S\@=" end="\S\@<=___\|___\S\@=" 
 " [link](URL) | [link][id] | [link][]
 syn region mkdFootnotes matchgroup=mkdDelimiter start="\[^"    end="\]"
 syn region mkdID matchgroup=mkdDelimiter        start="\["    end="\]" contained oneline
-syn region mkdURL matchgroup=mkdDelimiter       start="("     end=")"  contained oneline
+syn region mkdURL matchgroup=mkdDelimiter       start="("     end=")"  contained contains=mkdURLInnerParen oneline
 syn region mkdLink matchgroup=mkdDelimiter      start="\\\@<!\[" end="\]\ze\s*[[(]" contains=@Spell nextgroup=mkdURL,mkdID skipwhite oneline
+syn match  mkdURLInnerParen                     "([^)]*)" contained
 " mkd  inline links:           protocol   optional  user:pass@       sub/domain                 .com, .co.uk, etc      optional port   path/querystring/hash fragment
 "                            ------------ _____________________ --------------------------- ________________________ ----------------- __
 syntax match   mkdInlineURL /https\?:\/\/\(\w\+\(:\w\+\)\?@\)\?\([A-Za-z][-_0-9A-Za-z]*\.\)\{1,}\(\w\{2,}\.\?\)\{1,}\(:[0-9]\{1,5}\)\?\S*/
@@ -100,7 +101,7 @@ syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootno
 HtmlHiLink mkdString	    String
 HtmlHiLink mkdCode          String
 HtmlHiLink mkdIndentCode    String
-HtmlHiLink mkdFootnote    Comment
+HtmlHiLink mkdFootnote      Comment
 HtmlHiLink mkdBlockquote    Comment
 HtmlHiLink mkdLineContinue  Comment
 HtmlHiLink mkdListItem      Identifier
@@ -109,6 +110,7 @@ HtmlHiLink mkdLineBreak     Todo
 HtmlHiLink mkdFootnotes     htmlLink
 HtmlHiLink mkdLink          htmlLink
 HtmlHiLink mkdURL           htmlString
+HtmlHiLink mkdURLInnerParen mkdURL
 HtmlHiLink mkdInlineURL     htmlLink
 HtmlHiLink mkdID            Identifier
 HtmlHiLink mkdLinkDef       mkdID

--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -85,12 +85,12 @@ syn match  mkdRule         /^\s*-\{3,}$/
 syn match  mkdRule         /^\s*\*\{3,5}$/
 
 "HTML headings
-syn region htmlH1       start="^\s*#"                   end="\($\|#\+\)" contains=@Spell
-syn region htmlH2       start="^\s*##"                  end="\($\|#\+\)" contains=@Spell
-syn region htmlH3       start="^\s*###"                 end="\($\|#\+\)" contains=@Spell
-syn region htmlH4       start="^\s*####"                end="\($\|#\+\)" contains=@Spell
-syn region htmlH5       start="^\s*#####"               end="\($\|#\+\)" contains=@Spell
-syn region htmlH6       start="^\s*######"              end="\($\|#\+\)" contains=@Spell
+syn region htmlH1       start="^\s*#"                   end="\($\|[^\\]#\+\)" contains=@Spell
+syn region htmlH2       start="^\s*##"                  end="\($\|[^\\]#\+\)" contains=@Spell
+syn region htmlH3       start="^\s*###"                 end="\($\|[^\\]#\+\)" contains=@Spell
+syn region htmlH4       start="^\s*####"                end="\($\|[^\\]#\+\)" contains=@Spell
+syn region htmlH5       start="^\s*#####"               end="\($\|[^\\]#\+\)" contains=@Spell
+syn region htmlH6       start="^\s*######"              end="\($\|[^\\]#\+\)" contains=@Spell
 syn match  htmlH1       /^.\+\n=\+$/ contains=@Spell
 syn match  htmlH2       /^.\+\n-\+$/ contains=@Spell
 

--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -94,7 +94,7 @@ syn region htmlH6       start="^\s*######"              end="\($\|[^\\]#\+\)" co
 syn match  htmlH1       /^.\+\n=\+$/ contains=@Spell
 syn match  htmlH2       /^.\+\n-\+$/ contains=@Spell
 
-syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdID,mkdURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6
+syn cluster mkdNonListItem contains=htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdID,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdIndentCode,mkdListItem,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6
 
 "highlighting for Markdown groups
 HtmlHiLink mkdString	    String


### PR DESCRIPTION
**The issues fixed were:**

1. \\\<pre\>\\\</pre\\\> and \\\<code\\\>\\\</code\\\> would be recognized as code blocks despite being escaped.
2. Lines beginning with: \`\`\` {style=""} (a convention used at least by github and pandoc) aren't considered a **mkdCode** region, so the end region is seen as a start region, and everything in the document until the end of the next code block with a style region or the end of the document ends up being seen as a code block when it's supposed to be markdown or vice versa. I realize that this might not be standard markdown syntax (stated as a requirement in _CONTRIBUTING.md_), but if this is the case (and correct me if I'm wrong), I don't believe my change for this issue would match anything any differently in standard markdown.

Cheers!