### PR TITLE
Enable snippet plugins which do not recognize 'mkd' filetype

### DIFF
--- a/after/ftplugin/mkd.vim
+++ b/after/ftplugin/mkd.vim
@@ -54,3 +54,10 @@ if !get(g:, "vim_markdown_folding_disabled", 0)
   set foldmethod=expr
   set foldopen-=search
 endif
+
+" Enable snippet plugins which do not recognize 'mkd' filetype
+if exists(':UltiSnipsAddFiletypes') == 2
+  UltiSnipsAddFiletypes markdown
+elseif exists(':SnipMateLoadScope') == 2
+  SnipMateLoadScope markdown
+endif

--- a/after/ftplugin/mkd.vim
+++ b/after/ftplugin/mkd.vim
@@ -57,7 +57,8 @@ endif
 
 " Enable snippet plugins which do not recognize 'mkd' filetype
 if exists(':UltiSnipsAddFiletypes') == 2
-  UltiSnipsAddFiletypes markdown
+    UltiSnipsAddFiletypes markdown
 elseif exists(':SnipMateLoadScope') == 2
-  SnipMateLoadScope markdown
+    SnipMateLoadScope markdown
 endif
+


### PR DESCRIPTION
When I installed `vim-markdown` my snippets stopped working. It was due to the mkd file type. 

This solution was copied from:
https://github.com/tpope/vim-rails/blob/master/autoload/rails.vim

Alternatively this plugin could use `markdown` file type but I guess there was some other reason not to do it in the first place.