### PR TITLE
Fix escaped underscores contained in italics

### DIFF
--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -36,7 +36,7 @@ syn sync linebreaks=1
 
 "additions to HTML groups
 syn region htmlItalic start="\\\@<!\*\S\@=" end="\S\@<=\\\@<!\*" keepend oneline
-syn region htmlItalic start="\(^\|\s\)\@<=_\|\\\@<!_\([^_]\+\s\)\@=" end="\S\@<=_\|_\S\@=" keepend oneline
+syn region htmlItalic start="\(^\|\s\)\@<=_\|\\\@<!_\([^_]\+\s\)\@=" end="\S\@<=[^\\]_\|[^\\]_\S\@=" keepend oneline
 syn region htmlBold start="\S\@<=\*\*\|\*\*\S\@=" end="\S\@<=\*\*\|\*\*\S\@=" keepend oneline
 syn region htmlBold start="\S\@<=__\|__\S\@=" end="\S\@<=__\|__\S\@=" keepend oneline
 syn region htmlBoldItalic start="\S\@<=\*\*\*\|\*\*\*\S\@=" end="\S\@<=\*\*\*\|\*\*\*\S\@=" keepend oneline

--- a/test/syntax.md
+++ b/test/syntax.md
@@ -87,3 +87,46 @@ Should be a single link:
 [a] [b]
 
 [a] b [c](d)
+
+# Italics, bold and bold+italics
+
+The 'ipsum', escaped characters and 'dolor' should all be italic:
+
+lorem *ipsum\*dolor* sit
+
+lorem _ipsum\_dolor_ sit
+
+The 'ipsum', escaped characters and 'dolor' should all be bold:
+
+lorem **ipsum\*\*dolor** sit
+
+lorem __ipsum\_\_dolor__ sit
+
+The 'ipsum', escaped characters and 'dolor' should all be bold+italic:
+
+lorem ***ipsum\*\*\*dolor*** sit
+
+lorem ___ipsum\_\_\_dolor___ sit
+
+The escaped character and 'lorem' should be plain, and the 'ipsum' italic:
+
+\*lorem*ipsum*
+
+## Known failures
+
+The escaped character and 'lorem' should be plain, and the 'ipsum' italic:
+
+\_lorem_ipsum_
+
+The 'lorem' should be italic, and 'ipsum dolor' bold:
+
+\**lorem***ipsum dolor**
+
+\__lorem___ipsum dolor__
+
+The 'lorem' should be bold, and 'ipsum dolor' bold+italics:
+
+\***lorem*****ipsum dolor***
+
+\___lorem_____ipsum dolor___
+


### PR DESCRIPTION
Fix the issue where italics defined using underscores process an escaped underscore the same as one that isn't escaped, and end the italic markup in the text prematurely (as well as possibly creating new issues like inverted parsing? I didn't check that far.)

The unit tests include an example of the fixed issue, as well as examples of other similar concepts so they're easier to keep an eye on as the regex changes for other reasons. Each test or tests are collected under a new heading, and I did my best to organize them the same way as everything else in the file is organized. All that said, beyond being able to load them up in vim with the vim-markdown syntax loaded and evaluate by looking at how everything renders, there's nothing programmatic about my unit tests, and I wasn't sure if was expected as I skimmed through the **vim-vader** stuff without the time to really grasp how exactly how, when, where and with what it's been configured to be used with in this project. If what I've submitted is enough, or at the very least changes don't involve implementing the tests in **vim-vader**, then that sounds good, otherwise a quick point in the right direction would be helpful.

Cheers!