### PR TITLE
(Re)move formatoptions/comments to ftplugin

### DIFF
--- a/ftplugin/mkd.vim
+++ b/ftplugin/mkd.vim
@@ -1,3 +1,13 @@
+if exists("b:did_ftplugin")
+  finish
+endif
+
+runtime! ftplugin/markdown.vim
+
+" setlocal comments=fb:*,fb:-,fb:+,n:> commentstring=>\ %s
+" setlocal formatoptions+=tcqln formatoptions-=r formatoptions-=o
+" setlocal formatlistpat=^\\s*\\d\\+\\.\\s\\+\\\|^[-*+]\\s\\+
+
 "TODO print messages when on visual mode. I only see VISUAL, not the messages.
 
 " Function interface phylosophy:

--- a/syntax/mkd.vim
+++ b/syntax/mkd.vim
@@ -128,16 +128,6 @@ HtmlHiLink mkdLinkTitle     htmlString
 HtmlHiLink mkdMath          Statement
 HtmlHiLink mkdDelimiter     Delimiter
 
-" Automatically insert bullets
-setlocal formatoptions+=r
-" Do not automatically insert bullets when auto-wrapping with text-width
-setlocal formatoptions-=c
-" Accept various markers as bullets
-setlocal comments=b:*,b:+,b:-
-
-" Automatically continue blockquote on line break
-setlocal comments+=b:>
-
 let b:current_syntax = "mkd"
 
 delcommand HtmlHiLink


### PR DESCRIPTION
Do not set formatoptions/comments in syntax file!

Remove them and source it via `markdown` plugin via ftplugin.

This will now trigger the buggy indenting for everyone (#126), which should get fixed, before merging this.