### PR TITLE
Automatically format paragraphs

### DIFF
--- a/ftplugin/mkd.vim
+++ b/ftplugin/mkd.vim
@@ -444,3 +444,5 @@ command! -buffer Toc call s:Markdown_Toc()
 command! -buffer Toch call s:Markdown_Toc('horizontal')
 command! -buffer Tocv call s:Markdown_Toc('vertical')
 command! -buffer Toct call s:Markdown_Toc('tab')
+
+setlocal formatoptions+=a " Automatically format paragraphs


### PR DESCRIPTION
It's a common enough thing to manually format paragraphs in markdown files so I think it should be done automatically by default.