### PR TITLE
Remove nosmartindent: indentexpr overrules it.

### DIFF
--- a/indent/mkd.vim
+++ b/indent/mkd.vim
@@ -3,7 +3,6 @@ let b:did_indent = 1
 
 setlocal indentexpr=GetMkdIndent()
 setlocal nolisp
-setlocal nosmartindent
 setlocal autoindent
 
 " Only define the function once


### PR DESCRIPTION
Clearly stated on `:help indentexpr`.