### PR TITLE
README.md: add a section about issue reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,3 +37,18 @@ If you wish to have a behavior that differs from that style guide, add an option
 # Tests
 
 All new features must have unit tests.
+
+# Issues
+
+Issues are tracked within GitHub.
+
+When reporting issues, your report is more effective if you include a minimal example file that reproduces the problem. Try to trim out as much as possible, until you have the smallest possible file that still reproduces the issue. Paste the example inline into your issue report, quoted using four spaces at the beginning of each line, like this example from issue [#189](https://github.com/plasticboy/vim-markdown/issues/189):
+
+```
+Minimal example:
+
+    ```
+    =
+    ```
+    bad!
+```


### PR DESCRIPTION
This is a followup to cirosantilli's comments on issue [#187](https://github.com/plasticboy/vim-markdown/issues/187).

By the way, GFM seems to no longer add line breaks for single newlines, so there doesn't seem to be any reason not to wrap text to less than 79 characters per line. However, to avoid breaking style with the rest of the README, I unwrapped the new text anyway.