### PR TITLE
There is no such thing as buffer-local functions.

### DIFF
--- a/ftplugin/mkd.vim
+++ b/ftplugin/mkd.vim
@@ -471,7 +471,7 @@ endfunction
 " - multiline support
 " - give an error if the separator does is not on a link
 "
-function! b:Markdown_GetUrlForPosition(lnum, col)
+function! s:Markdown_GetUrlForPosition(lnum, col)
     let l:lnum = a:lnum
     let l:col = a:col
     let l:syn = synIDattr(synID(l:lnum, l:col, 1), 'name')
@@ -504,7 +504,7 @@ endfunction
 " Front end for GetUrlForPosition.
 "
 function! s:OpenUrlUnderCursor()
-    let l:url = b:Markdown_GetUrlForPosition(line('.'), col('.'))
+    let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
     if l:url != ''
         call netrw#NetrwBrowseX(l:url, 0)
     else


### PR DESCRIPTION
.. atleast not anymore, and Vim want's capital functionnames or
begining with 's:'.