### PR TITLE
Build latest vim quickly from git mirror.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
 language: vim
+env:
+  - TEST=package
+  - TEST=latest
 
-install: |
-  sudo apt-get update
-  sudo apt-get install vim
+before_script: |
   cd ..
+  if [ "$TEST" = "package" ]; then
+    sudo apt-get -y update
+    sudo apt-get -y install vim
+  else
+    git clone --depth 1 https://github.com/vim/vim
+    cd vim
+    ./configure --with-features=huge
+    make
+    sudo make install
+    export PATH="/usr/local/bin:$PATH"
+    cd -
+  fi
   git clone https://github.com/godlygeek/tabular
   git clone https://github.com/junegunn/vader.vim
 


### PR DESCRIPTION
* Run tests against latest vim & stock.
* Fixes #201

From the language I understood you still wanted to test against stock & also latest vim 7.4 line. So that's what this does. You can later add any other version/config of vim by simply using another RVM.