### PR TITLE
Set nogdefault in TableFormat function.

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -391,6 +391,8 @@ endfunction
 " Depends on Tabularize.
 "
 function! s:TableFormat()
+    let l:gdefault = &gdefault
+    set nogdefault
     let l:pos = getpos('.')
     normal! {
     " Search instead of `normal! j` because of the table at beginning of file edge case.
@@ -402,6 +404,7 @@ function! s:TableFormat()
     Tabularize /|
     s/ /-/g
     call setpos('.', l:pos)
+    let &gdefault = l:gdefault
 endfunction
 
 " Wrapper to do move commands in visual mode.


### PR DESCRIPTION
If you have gdefault set in your .vimrc, TableFormat function doesn't perform correctly.
This PR fixes it.