### PR TITLE
Add the indent part of the plugin to the registry

### DIFF
--- a/registry/markdown.yaml
+++ b/registry/markdown.yaml
@@ -5,3 +5,4 @@ files:
   - ftplugin/markdown.vim
   - syntax/markdown.vim
   - after/ftplugin/markdown.vim
+  - indent/markdown.vim


### PR DESCRIPTION
Seems the "indent" was forgotten, any reason behind it?