### PR TITLE
Use just markdown as filetype.

### DIFF
--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -1,3 +1,3 @@
 " markdown filetype file
-au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn}   set filetype=mkd.markdown
-au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn}.{des3,des,bf,bfa,aes,idea,cast,rc2,rc4,rc5,desx} set filetype=mkd.markdown
+au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn} set filetype=markdown
+au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn}.{des3,des,bf,bfa,aes,idea,cast,rc2,rc4,rc5,desx} set filetype=markdown


### PR DESCRIPTION
. for multiple filetypes does not work with autocmd.
    
There seems to be no known workaround:
http://vi.stackexchange.com/questions/4893
   
This is a breaking change as it would break user scripts
who used autocmd, but we have already broken them
with this compound filetype, so let's just finish the job.
    
Semi-reverses: https://github.com/plasticboy/vim-markdown/pull/217
