### PR TITLE
Makefile: support DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VIMDIR=/usr/share/vim
+VIMDIR=$(DESTDIR)/usr/share/vim
 ADDONS=${VIMDIR}/addons
 REGISTRY=${VIMDIR}/registry
 


### PR DESCRIPTION
DESTDIR is set by distributors when packaging. So to be
able to use make install there, put DESTDIR in from of
PREFIX.