### PR TITLE
Fix errors when opening markdown file with vim-filetype code blocks.

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -668,6 +668,8 @@ function! s:SyntaxInclude(filetype)
     try
         execute 'syntax include' grouplistname 'syntax/' . a:filetype . '.vim'
         execute 'syntax include' grouplistname 'after/syntax/' . a:filetype . '.vim'
+    catch /E403/
+        " Ignore syntax patterns specified twice
     catch /E484/
         " Ignore missing scripts
     endtry


### PR DESCRIPTION
I encountered this error when opening markdown file with vim-filetype code blocks.

```vim
Error detected while processing C:\Program Files\Vim\vim74\syntax\vim.vim:
line  777:
E403: syntax sync: line continuations pattern specified twice
Error detected while processing function <SNR>87_MarkdownRefreshSyntax[2]..<SNR>87_MarkdownHighlightSources:
line   26:
E171: Missing :endif
Error detected while processing function <SNR>87_MarkdownRefreshSyntax:
line    2:
E171: Missing :endif
```

[vim-notes](https://github.com/xolox/vim-notes/) had the same issue but fixed it by [this commit](https://github.com/xolox/vim-notes/commit/825230ab7fdec7de83a036c18daec0621cfd67d3).
This PR is the same as it.