### PR TITLE
Add option for singleline emphasis

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ It never increases its default size (half screen), it only shrinks.
 let g:vim_markdown_toc_autofit = 1
 ```
 
+### Text emphasis restriction to single-lines
+
+By default text emphasis works across multiple lines until a closing token is found. However, it's possible to restrict text emphasis to a single line (ie, for it to be applied a closing token must be found on the same line). To do so:
+```vim
+let g:vim_markdown_emphasis_multiline = 0
+```
+
 ### Syntax Concealing
 
 Concealing is set for some syntax.

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -51,6 +51,7 @@ if get(g:, "vim_markdown_emphasis_multiline", 1)
     syn region htmlBoldItalic start="___\ze\S" end="\S\zs___" keepend
 else
     " single-line emphasis (emphasis only works with closing token on the same line)
+    " the following character makes the match non-greedy:          vv
     syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]\([^\n\*]*[^\\\*\t ]\)\?\*" end="[^\\\*\t ]\zs\*\ze\_W" keepend
     syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]\([^\n_]*[^\\_\t ]\)\?_" end="[^\\_\t ]\zs_\ze\_W" keepend
     syn region htmlBold start="\*\*\ze\S\([^\n\*]*[^\\\*\t ]\)\?\*\*" end="\S\zs\*\*" keepend

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -43,21 +43,16 @@ endif
 
 "additions to HTML groups
 if get(g:, "vim_markdown_emphasis_multiline", 1)
-    syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]" end="[^\\\*\t ]\zs\*\ze\_W" keepend
-    syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend
-    syn region htmlBold start="\*\*\ze\S" end="\S\zs\*\*" keepend
-    syn region htmlBold start="__\ze\S" end="\S\zs__" keepend
-    syn region htmlBoldItalic start="\*\*\*\ze\S" end="\S\zs\*\*\*" keepend
-    syn region htmlBoldItalic start="___\ze\S" end="\S\zs___" keepend
+    let oneline = ""
 else
-    " single-line emphasis (emphasis only works with closing token on the same line)
-    syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]\([^\n]*[^\\\*\t ]\)\?\*" end="[^\\\*\t ]\zs\*\ze\_W" keepend
-    syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]\([^\n]*[^\\_\t ]\)\?_" end="[^\\_\t ]\zs_\ze\_W" keepend
-    syn region htmlBold start="\*\*\ze\S\([^\n]*[^\\\*\t ]\)\?\*\*" end="\S\zs\*\*" keepend
-    syn region htmlBold start="__\ze\S\([^\n]*[^\\_\t ]\)\?__" end="\S\zs__" keepend
-    syn region htmlBold start="\*\*\*\ze\S\([^\n]*[^\\\*\t ]\)\?\*\*\*" end="\S\zs\*\*\*" keepend
-    syn region htmlBold start="___\ze\S\([^\n]*[^\\_\t ]\)\?___" end="\S\zs___" keepend
+    let oneline = " oneline"
 endif
+execute 'syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]" end="[^\\\*\t ]\zs\*\ze\_W" keepend' . oneline
+execute 'syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend' . oneline
+execute 'syn region htmlBold start="\*\*\ze\S" end="\S\zs\*\*" keepend' . oneline
+execute 'syn region htmlBold start="__\ze\S" end="\S\zs__" keepend' . oneline
+execute 'syn region htmlBoldItalic start="\*\*\*\ze\S" end="\S\zs\*\*\*" keepend' . oneline
+execute 'syn region htmlBoldItalic start="___\ze\S" end="\S\zs___" keepend' . oneline
 
 " [link](URL) | [link][id] | [link][] | ![image](URL)
 syn region mkdFootnotes matchgroup=mkdDelimiter start="\[^"    end="\]"

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -42,31 +42,22 @@ if has('conceal')
 endif
 
 "additions to HTML groups
-"syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]" end="[^\\\*\t ]\zs\*\ze\_W" keepend
-"syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend
-"syn region htmlBold start="\*\*\ze\S" end="\S\zs\*\*" keepend
-"syn region htmlBold start="__\ze\S" end="\S\zs__" keepend
-"syn region htmlBoldItalic start="\*\*\*\ze\S" end="\S\zs\*\*\*" keepend
-"syn region htmlBoldItalic start="___\ze\S" end="\S\zs___" keepend
-
-" emphasis stops at newline (in case a closing token is not found before)
-"if get(g:, "vim_markdown_emphasis_stops_at_newline", 1)
-"    let esanl_pre = '\(\n\|'
-"    let esanl_suf = '\)'
-"else
-"    let esanl_pre = ''
-"    let esanl_suf = ''
-"endif
-"execute 'syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]" end="[^\\\*\t ]\zs' . esanl_pre . '\*' . esanl_suf . '\ze\_W" keepend'
-"execute 'syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs' . esanl_pre . '_' . esanl_suf . '\ze\_W" keepend'
-"execute 'syn region htmlBold start="\*\*\ze\S" end="\S\zs' . esanl_pre . '\*\*' . esanl_suf . '" keepend'
-"execute 'syn region htmlBold start="__\ze\S" end="\S\zs__" keepend
-"execute 'syn region htmlBoldItalic start="\*\*\*\ze\S" end="\S\zs\*\*\*" keepend
-"execute 'syn region htmlBoldItalic start="___\ze\S" end="\S\zs___" keepend
-
-" single-line emphasis (emphasis only works with matching token in the same line)
-syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]\([^\n]*[^\\\*\t ]\)\?\*" end="[^\\\*\t ]\zs\*\ze\_W" keepend
-
+if get(g:, "vim_markdown_emphasis_multiline", 1)
+    syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]" end="[^\\\*\t ]\zs\*\ze\_W" keepend
+    syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend
+    syn region htmlBold start="\*\*\ze\S" end="\S\zs\*\*" keepend
+    syn region htmlBold start="__\ze\S" end="\S\zs__" keepend
+    syn region htmlBoldItalic start="\*\*\*\ze\S" end="\S\zs\*\*\*" keepend
+    syn region htmlBoldItalic start="___\ze\S" end="\S\zs___" keepend
+else
+    " single-line emphasis (emphasis only works with closing token on the same line)
+    syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]\([^\n\*]*[^\\\*\t ]\)\?\*" end="[^\\\*\t ]\zs\*\ze\_W" keepend
+    syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]\([^\n_]*[^\\_\t ]\)\?_" end="[^\\_\t ]\zs_\ze\_W" keepend
+    syn region htmlBold start="\*\*\ze\S\([^\n\*]*[^\\\*\t ]\)\?\*\*" end="\S\zs\*\*" keepend
+    syn region htmlBold start="__\ze\S\([^\n_]*[^\\_\t ]\)\?__" end="\S\zs__" keepend
+    syn region htmlBold start="\*\*\*\ze\S\([^\n\*]*[^\\\*\t ]\)\?\*\*\*" end="\S\zs\*\*\*" keepend
+    syn region htmlBold start="___\ze\S\([^\n_]*[^\\_\t ]\)\?___" end="\S\zs___" keepend
+endif
 
 " [link](URL) | [link][id] | [link][] | ![image](URL)
 syn region mkdFootnotes matchgroup=mkdDelimiter start="\[^"    end="\]"

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -51,13 +51,12 @@ if get(g:, "vim_markdown_emphasis_multiline", 1)
     syn region htmlBoldItalic start="___\ze\S" end="\S\zs___" keepend
 else
     " single-line emphasis (emphasis only works with closing token on the same line)
-    " the following character makes the match non-greedy:          vv
-    syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]\([^\n\*]*[^\\\*\t ]\)\?\*" end="[^\\\*\t ]\zs\*\ze\_W" keepend
-    syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]\([^\n_]*[^\\_\t ]\)\?_" end="[^\\_\t ]\zs_\ze\_W" keepend
-    syn region htmlBold start="\*\*\ze\S\([^\n\*]*[^\\\*\t ]\)\?\*\*" end="\S\zs\*\*" keepend
-    syn region htmlBold start="__\ze\S\([^\n_]*[^\\_\t ]\)\?__" end="\S\zs__" keepend
-    syn region htmlBold start="\*\*\*\ze\S\([^\n\*]*[^\\\*\t ]\)\?\*\*\*" end="\S\zs\*\*\*" keepend
-    syn region htmlBold start="___\ze\S\([^\n_]*[^\\_\t ]\)\?___" end="\S\zs___" keepend
+    syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]\([^\n]*[^\\\*\t ]\)\?\*" end="[^\\\*\t ]\zs\*\ze\_W" keepend
+    syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]\([^\n]*[^\\_\t ]\)\?_" end="[^\\_\t ]\zs_\ze\_W" keepend
+    syn region htmlBold start="\*\*\ze\S\([^\n]*[^\\\*\t ]\)\?\*\*" end="\S\zs\*\*" keepend
+    syn region htmlBold start="__\ze\S\([^\n]*[^\\_\t ]\)\?__" end="\S\zs__" keepend
+    syn region htmlBold start="\*\*\*\ze\S\([^\n]*[^\\\*\t ]\)\?\*\*\*" end="\S\zs\*\*\*" keepend
+    syn region htmlBold start="___\ze\S\([^\n]*[^\\_\t ]\)\?___" end="\S\zs___" keepend
 endif
 
 " [link](URL) | [link][id] | [link][] | ![image](URL)

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -42,12 +42,31 @@ if has('conceal')
 endif
 
 "additions to HTML groups
-syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]" end="[^\\\*\t ]\zs\*\ze\_W" keepend
-syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend
-syn region htmlBold start="\*\*\ze\S" end="\S\zs\*\*" keepend
-syn region htmlBold start="__\ze\S" end="\S\zs__" keepend
-syn region htmlBoldItalic start="\*\*\*\ze\S" end="\S\zs\*\*\*" keepend
-syn region htmlBoldItalic start="___\ze\S" end="\S\zs___" keepend
+"syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]" end="[^\\\*\t ]\zs\*\ze\_W" keepend
+"syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs_\ze\_W" keepend
+"syn region htmlBold start="\*\*\ze\S" end="\S\zs\*\*" keepend
+"syn region htmlBold start="__\ze\S" end="\S\zs__" keepend
+"syn region htmlBoldItalic start="\*\*\*\ze\S" end="\S\zs\*\*\*" keepend
+"syn region htmlBoldItalic start="___\ze\S" end="\S\zs___" keepend
+
+" emphasis stops at newline (in case a closing token is not found before)
+"if get(g:, "vim_markdown_emphasis_stops_at_newline", 1)
+"    let esanl_pre = '\(\n\|'
+"    let esanl_suf = '\)'
+"else
+"    let esanl_pre = ''
+"    let esanl_suf = ''
+"endif
+"execute 'syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]" end="[^\\\*\t ]\zs' . esanl_pre . '\*' . esanl_suf . '\ze\_W" keepend'
+"execute 'syn region htmlItalic start="\%(^\|\s\)\zs_\ze[^\\_\t ]" end="[^\\_\t ]\zs' . esanl_pre . '_' . esanl_suf . '\ze\_W" keepend'
+"execute 'syn region htmlBold start="\*\*\ze\S" end="\S\zs' . esanl_pre . '\*\*' . esanl_suf . '" keepend'
+"execute 'syn region htmlBold start="__\ze\S" end="\S\zs__" keepend
+"execute 'syn region htmlBoldItalic start="\*\*\*\ze\S" end="\S\zs\*\*\*" keepend
+"execute 'syn region htmlBoldItalic start="___\ze\S" end="\S\zs___" keepend
+
+" single-line emphasis (emphasis only works with matching token in the same line)
+syn region htmlItalic start="\%(^\|\s\)\zs\*\ze[^\\\*\t ]\([^\n]*[^\\\*\t ]\)\?\*" end="[^\\\*\t ]\zs\*\ze\_W" keepend
+
 
 " [link](URL) | [link][id] | [link][] | ![image](URL)
 syn region mkdFootnotes matchgroup=mkdDelimiter start="\[^"    end="\]"

--- a/test/syntax-singleline.vader
+++ b/test/syntax-singleline.vader
@@ -1,0 +1,158 @@
+Before:
+  let g:vim_markdown_emphasis_multiline = 0
+  syn off | syn on
+
+After:
+  let g:vim_markdown_emphasis_multiline = 1
+  syn off | syn on
+
+Given markdown;
+a **b** c
+
+Execute (bold):
+  AssertNotEqual SyntaxOf('a'), 'htmlBold'
+  AssertEqual SyntaxOf('b'), 'htmlBold'
+  AssertNotEqual SyntaxOf('c'), 'htmlBold'
+
+Given markdown;
+a __b__ c
+
+Execute (bold):
+  AssertNotEqual SyntaxOf('a'), 'htmlBold'
+  AssertEqual SyntaxOf('b'), 'htmlBold'
+  AssertNotEqual SyntaxOf('c'), 'htmlBold'
+
+Given markdown;
+a *b* c
+
+Execute (italic):
+  AssertNotEqual SyntaxOf('a'), 'htmlItalic'
+  AssertEqual SyntaxOf('b'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('c'), 'htmlItalic'
+
+Given markdown;
+a _b_ c
+
+Execute (italic):
+  AssertNotEqual SyntaxOf('a'), 'htmlItalic'
+  AssertEqual SyntaxOf('b'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('c'), 'htmlItalic'
+
+Given markdown;
+_a_b_
+
+Execute (italic text has underscores):
+  AssertEqual SyntaxOf('a'), 'htmlItalic'
+  AssertEqual SyntaxOf('b'), 'htmlItalic'
+
+Given markdown;
+a \*b\* c
+
+Execute (not italic with escaped asterisks):
+  AssertNotEqual SyntaxOf('a'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('b'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('c'), 'htmlItalic'
+
+Given markdown;
+a \_b\_ c
+
+Execute (not italic with escaped underscores):
+  AssertNotEqual SyntaxOf('a'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('b'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('c'), 'htmlItalic'
+
+Given markdown;
+a _b\_c_ d
+
+Execute (italic with escaped underscores):
+  AssertNotEqual SyntaxOf('a'), 'htmlItalic'
+  AssertEqual SyntaxOf('b'), 'htmlItalic'
+  AssertEqual SyntaxOf('c'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('d'), 'htmlItalic'
+
+Given markdown;
+a_b_c
+
+Execute (not italic underscores within text):
+  AssertNotEqual SyntaxOf('a'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('b'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('c'), 'htmlItalic'
+
+Given markdown;
+a *b\*c* d
+
+Execute (italic with escaped asterisks):
+  AssertNotEqual SyntaxOf('a'), 'htmlItalic'
+  AssertEqual SyntaxOf('b'), 'htmlItalic'
+  AssertEqual SyntaxOf('c'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('d'), 'htmlItalic'
+
+Given markdown;
+a __b\_\_c__ d
+
+Execute (bold with escaped underscores):
+  AssertNotEqual SyntaxOf('a'), 'htmlBold'
+  AssertEqual SyntaxOf('b'), 'htmlBold'
+  AssertEqual SyntaxOf('c'), 'htmlBold'
+  AssertNotEqual SyntaxOf('d'), 'htmlBold'
+
+Given markdown;
+_a b
+c_ d
+
+Execute (italic with underscores in multiple lines):
+  AssertNotEqual SyntaxOf('a'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('b'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('c'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('d'), 'htmlItalic'
+
+Given markdown;
+__a b
+c__ d
+
+Execute (bold with underscores in multiple lines):
+  AssertNotEqual SyntaxOf('a'), 'htmlBold'
+  AssertNotEqual SyntaxOf('b'), 'htmlBold'
+  AssertNotEqual SyntaxOf('c'), 'htmlBold'
+  AssertNotEqual SyntaxOf('d'), 'htmlBold'
+
+Given markdown;
+___a b
+c___ d
+
+Execute (bold italic with underscores in multiple lines):
+  AssertNotEqual SyntaxOf('a'), 'htmlBoldItalic'
+  AssertNotEqual SyntaxOf('b'), 'htmlBoldItalic'
+  AssertNotEqual SyntaxOf('c'), 'htmlBoldItalic'
+  AssertNotEqual SyntaxOf('d'), 'htmlBoldItalic'
+
+Given markdown;
+*a b
+c* d
+
+Execute (italic with asterisks in multiple lines):
+  AssertNotEqual SyntaxOf('a'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('b'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('c'), 'htmlItalic'
+  AssertNotEqual SyntaxOf('d'), 'htmlItalic'
+
+Given markdown;
+**a b
+c** d
+
+Execute (bold with asterisks in multiple lines):
+  AssertNotEqual SyntaxOf('a'), 'htmlBold'
+  AssertNotEqual SyntaxOf('b'), 'htmlBold'
+  AssertNotEqual SyntaxOf('c'), 'htmlBold'
+  AssertNotEqual SyntaxOf('d'), 'htmlBold'
+
+Given markdown;
+***a b
+c*** d
+
+Execute (bold italic with asterisks in multiple lines):
+  AssertNotEqual SyntaxOf('a'), 'htmlBoldItalic'
+  AssertNotEqual SyntaxOf('b'), 'htmlBoldItalic'
+  AssertNotEqual SyntaxOf('c'), 'htmlBoldItalic'
+  AssertNotEqual SyntaxOf('d'), 'htmlBoldItalic'
+


### PR DESCRIPTION
By default text emphasis works across multiple lines until a closing token is found. This PR adds an user option to restrict text emphasis to a single line (ie, for it to be applied a closing token must be found on the same line).