### PR TITLE
Fix URL syntax regex

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -62,8 +62,8 @@ execute 'syn region mkdLink matchgroup=mkdDelimiter  start="\\\@<!!\?\[" end="\n
 
 " Autolink without angle brackets.
 " mkd  inline links:           protocol   optional  user:pass@       sub/domain                 .com, .co.uk, etc      optional port   path/querystring/hash fragment
-"                            ------------ _____________________ --------------------------- ________________________ ----------------- __
-syntax match   mkdInlineURL /https\?:\/\/\(\w\+\(:\w\+\)\?@\)\?\([A-Za-z][-_0-9A-Za-z]*\.\)\{1,}\(\w\{2,}\.\?\)\{1,}\(:[0-9]\{1,5}\)\?\S*/
+"                            ------------ _____________________ ----------------------------- ________________________ ----------------- __
+syntax match   mkdInlineURL /https\?:\/\/\(\w\+\(:\w\+\)\?@\)\?\([A-Za-z0-9][-_0-9A-Za-z]*\.\)\{1,}\(\w\{2,}\.\?\)\{1,}\(:[0-9]\{1,5}\)\?\S*/
 
 " Autolink with parenthesis.
 syntax region  mkdInlineURL matchgroup=mkdDelimiter start="(\(https\?:\/\/\(\w\+\(:\w\+\)\?@\)\?\([A-Za-z][-_0-9A-Za-z]*\.\)\{1,}\(\w\{2,}\.\?\)\{1,}\(:[0-9]\{1,5}\)\?\S*)\)\@=" end=")"

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -218,6 +218,12 @@ Execute (autolink):
   AssertNotEqual SyntaxOf('c'), 'mkdInlineURL'
 
 Given markdown;
+http://12monkeys.foo
+
+Execute (autolink with domain starting with a number):
+  AssertEqual SyntaxOf('12monkeys'), 'mkdInlineURL'
+
+Given markdown;
 <HtTp://a>
 
 Execute (autolink with scheme case is insensitive):


### PR DESCRIPTION
Enables domain names that start with digits

