### PR TITLE
Add 'g:markdown_conceal'

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ Concealing is set for some syntax.
 
 For example, conceal `[link text](link url)` as just `link text`.
 
-To enable/disable conceal use Vim's standard conceal configuration.
+To disable conceal, add the following to your '.vimrc':
 
 ```vim
-set conceallevel=2
+let g:vim_markdown_markdown_conceal = 0
 ```
 
 ### Syntax extensions

--- a/doc/vim-markdown.txt
+++ b/doc/vim-markdown.txt
@@ -135,16 +135,16 @@ for it to be applied a closing token must be found on the same line). To do so:
   let g:vim_markdown_emphasis_multiline = 0
 <
 -------------------------------------------------------------------------------
-                                               *vim-markdown-syntax-concealing*
+                                               *vim_markdown_markdown_conceal*
 Syntax Concealing ~
 
 Concealing is set for some syntax.
 
 For example, conceal '[link text](link url)' as just 'link text'.
 
-To enable/disable conceal use Vim's standard conceal configuration.
+To disable conceal, add the following to your '.vimrc':
 >
-  set conceallevel=2
+  let g:vim_markdown_markdown_conceal = 0
 <
 -------------------------------------------------------------------------------
                                                *vim-markdown-syntax-extensions*

--- a/doc/vim-markdown.txt
+++ b/doc/vim-markdown.txt
@@ -135,7 +135,7 @@ for it to be applied a closing token must be found on the same line). To do so:
   let g:vim_markdown_emphasis_multiline = 0
 <
 -------------------------------------------------------------------------------
-                                               *vim_markdown_markdown_conceal*
+                                               *vim-markdown-syntax-concealing*
 Syntax Concealing ~
 
 Concealing is set for some syntax.

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -658,7 +658,7 @@ function! s:MarkdownHighlightSources(force)
                 let include = '@' . toupper(filetype)
             endif
             let command = 'syntax region %s matchgroup=%s start="^\s*```%s$" matchgroup=%s end="\s*```$" keepend contains=%s%s'
-            execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') && get(g:, 'markdown_conceal', 1) ? ' concealends' : '')
+            execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') && get(g:, 'vim_markdown_markdown_conceal', 1) ? ' concealends' : '')
             execute printf('syntax cluster mkdNonListItem add=%s', group)
 
             let b:mkd_known_filetypes[ft] = 1

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -658,7 +658,7 @@ function! s:MarkdownHighlightSources(force)
                 let include = '@' . toupper(filetype)
             endif
             let command = 'syntax region %s matchgroup=%s start="^\s*```%s$" matchgroup=%s end="\s*```$" keepend contains=%s%s'
-            execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') ? ' concealends' : '')
+            execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') && get(g:, 'markdown_conceal', 1) ? ' concealends' : '')
             execute printf('syntax cluster mkdNonListItem add=%s', group)
 
             let b:mkd_known_filetypes[ft] = 1

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -36,7 +36,7 @@ syn sync linebreaks=1
 
 let s:conceal = ''
 let s:concealends = ''
-if has('conceal')
+if has('conceal') && get(g:, 'markdown_conceal', 1)
   let s:conceal = ' conceal'
   let s:concealends = ' concealends'
 endif

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -36,7 +36,7 @@ syn sync linebreaks=1
 
 let s:conceal = ''
 let s:concealends = ''
-if has('conceal') && get(g:, 'markdown_conceal', 1)
+if has('conceal') && get(g:, 'vim_markdown_markdown_conceal', 1)
   let s:conceal = ' conceal'
   let s:concealends = ' concealends'
 endif


### PR DESCRIPTION
Add variable 'g:markdown_conceal' to enable/disable markdown conceal.
In vimrc,
```vim
let g:markdown_conceal = 1 " conceal enable
let g:markdown_conceal = 0 " conceal disable
```
Default : 1