### PR TITLE
Make new list item indent configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,28 @@ JSON syntax highlight requires [vim-json](https://github.com/elzr/vim-json).
 let g:vim_markdown_json_frontmatter = 1
 ```
 
+### Adjust new list item indent
+
+You can adjust a new list indent. For example, you insert a single line like below:
+
+```
+* item1
+```
+
+Then if you type `o` to insert new line in vim and type `* item2`, the result will be:
+
+```
+* item1
+    * item2
+```
+
+vim-markdown automatically insert the indent. By default, the number of spaces of indent is 4. If you'd like to change the number as 2, just write:
+
+```vim
+let g:vim_markdown_new_list_item_indent = 2
+```
+
+
 ## Mappings
 
 The following work on normal and visual modes:

--- a/doc/vim-markdown.txt
+++ b/doc/vim-markdown.txt
@@ -20,6 +20,7 @@ Contents ~
    2. YAML Front Matter                        |vim-markdown-yaml-front-matter|
    3. TOML Front Matter                        |vim-markdown-toml-front-matter|
    4. JSON Front Matter                        |vim-markdown-json-front-matter|
+  10. Adjust new list item indent    |vim-markdown-adjust-new-list-item-indent|
  4. Mappings                                            |vim-markdown-mappings|
  5. Commands                                            |vim-markdown-commands|
  6. Credits                                              |vim-markdown-credits|
@@ -212,6 +213,26 @@ Highlight JSON front matter as used by Hugo [7].
 JSON syntax highlight requires vim-json [9].
 >
   let g:vim_markdown_json_frontmatter = 1
+<
+-------------------------------------------------------------------------------
+                                     *vim-markdown-adjust-new-list-item-indent*
+Adjust new list item indent ~
+
+You can adjust a new list indent. For example, you insert a single line like
+below:
+>
+  * item1
+<
+Then if you type 'o' to insert new line in vim and type '* item2', the result
+will be:
+>
+  * item1
+      * item2
+<
+vim-markdown automatically insert the indent. By default, the number of spaces
+of indent is 4. If you'd like to change the number as 2, just write:
+>
+  let g:vim_markdown_new_list_item_indent = 2
 <
 ===============================================================================
                                                         *vim-markdown-mappings*

--- a/indent/markdown.vim
+++ b/indent/markdown.vim
@@ -48,7 +48,7 @@ function GetMarkdownIndent()
     if v:lnum > 2 && s:IsBlankLine(getline(v:lnum - 1)) && s:IsBlankLine(getline(v:lnum - 2))
         return 0
     endif
-    let list_ind = 4
+    let list_ind = get(g:, "vim_markdown_new_list_item_indent", 4)
     " Find a non-blank line above the current line.
     let lnum = s:PrevNonBlank(v:lnum - 1)
     " At the start of the file use zero indent.

--- a/test/indent-new-list-item.vader
+++ b/test/indent-new-list-item.vader
@@ -1,0 +1,15 @@
+Before:
+  let g:vim_markdown_new_list_item_indent = 2
+
+After:
+  unlet g:vim_markdown_new_list_item_indent
+
+Given markdown;
+* item1
+
+Do (new line from the first item of the list and add the second item):
+  o* item2
+
+Expect (insert 2 spaces to the head of second item):
+  * item1
+    * item2

--- a/test/indent.vader
+++ b/test/indent.vader
@@ -61,3 +61,13 @@ Expect (no indent header after list):
   -   a
 
   ## b
+
+Given markdown;
+* item1
+
+Do (new line from the first item of the list and add the second item):
+  o* item2
+
+Expect (insert 4 spaces to the head of second item):
+  * item1
+      * item2


### PR DESCRIPTION
# Overview

before the pull request, we cannot configure new list item indent because it was fixed. i always insert 2-space indent for new list item, so i'd like to make it configurable.

i didn't change default behavior (the original number of spaces was 4, so i set default as 4).


# What is changed

You can adjust a new list indent. For example, you insert a single line like below:

```
* item1
```

Then if you type `o` to insert new line in vim and type `* item2`, the result will be:

```
* item1
    * item2
```

vim-markdown automatically insert the indent. By default, the number of spaces of indent is 4. If you'd like to change the number as 2, just write:

```vim
let g:vim_markdown_new_list_item_indent = 2
```