### PR TITLE
Support more general fenced code block

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -640,7 +640,7 @@ function! s:MarkdownHighlightSources(force)
     " Look for code blocks in the current file
     let filetypes = {}
     for line in getline(1, '$')
-        let ft = matchstr(line, '```\zs[0-9A-Za-z_+-]*')
+        let ft = matchstr(line, '```\s*\zs[0-9A-Za-z_+-]*')
         if !empty(ft) && ft !~ '^\d*$' | let filetypes[ft] = 1 | endif
     endfor
     if !exists('b:mkd_known_filetypes')
@@ -671,7 +671,7 @@ function! s:MarkdownHighlightSources(force)
             else
                 let include = '@' . toupper(filetype)
             endif
-            let command = 'syntax region %s matchgroup=%s start="^\s*```%s$" matchgroup=%s end="\s*```$" keepend contains=%s%s'
+            let command = 'syntax region %s matchgroup=%s start="^\s*```\s*%s$" matchgroup=%s end="\s*```$" keepend contains=%s%s'
             execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') && get(g:, 'vim_markdown_conceal', 1) ? ' concealends' : '')
             execute printf('syntax cluster mkdNonListItem add=%s', group)
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1,3 +1,7 @@
+Before:
+  unlet! b:mkd_known_filetypes
+  unlet! b:mkd_included_filetypes
+
 Given markdown;
 a **b** c
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -424,6 +424,36 @@ Execute (fenced code block syntax with a language specifier):
   AssertEqual SyntaxOf('def'), 'rubyDefine'
 
 Given markdown;
+``` c++
+#include <iostream>
+code
+```
+
+```  vim
+let g:a = 1
+```
+
+```	ruby
+def a
+end
+```
+
+```
+ruby
+class B
+end
+```
+
+Execute (fenced code block syntax with a language specifier after whitespace):
+  let b:func = Markdown_GetFunc('vim-markdown/ftplugin/markdown.vim', 'MarkdownRefreshSyntax')
+  call b:func(0)
+  AssertEqual SyntaxOf('include'), 'cInclude'
+  AssertEqual SyntaxOf('code'), 'mkdSnippetCPP'
+  AssertEqual SyntaxOf('g:a'), 'vimVar'
+  AssertEqual SyntaxOf('def'), 'rubyDefine'
+  AssertNotEqual SyntaxOf('class'), 'rubyClass'
+
+Given markdown;
 ```vim
 let g:a = 1
 ```


### PR DESCRIPTION
I usually see fenced code block with a language specifier followed by \`\`\` and some whitespace. This pull request supports highlighting them.