### PR TITLE
Implement "edit link in Vim" shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ The following work on normal and visual modes:
 
     Known limitation: does not work for links that span multiple lines.
 
+-   `ge`: open the link under the cursor in Vim for editing. Useful for relative markdown links. `<Plug>Markdown_EditUrlUnderCursor`
+
+    The rules for the cursor position are the same as the `gx` command.
+
 -   `]]`: go to next header. `<Plug>Markdown_MoveToNextHeader`
 
 -   `[[`: go to previous header. Contrast with `]c`. `<Plug>Markdown_MoveToPreviousHeader`

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -576,6 +576,19 @@ function! s:OpenUrlUnderCursor()
     endif
 endfunction
 
+" We need a definition guard because we invoke 'edit' which will reload this
+" script while this function is running. We must not replace it.
+if !exists("*s:EditUrlUnderCursor")
+  function s:EditUrlUnderCursor()
+      let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
+      if l:url != ''
+          execute 'edit' l:url
+      else
+          echomsg 'The cursor is not on a link.'
+      endif
+  endfunction
+endif
+
 function! s:VersionAwareNetrwBrowseX(url)
     if has('patch-7.4.567')
         call netrw#BrowseX(a:url, 0)
@@ -598,6 +611,7 @@ call <sid>MapNormVis('<Plug>Markdown_MoveToPreviousSiblingHeader', '<sid>MoveToP
 call <sid>MapNormVis('<Plug>Markdown_MoveToParentHeader', '<sid>MoveToParentHeader')
 call <sid>MapNormVis('<Plug>Markdown_MoveToCurHeader', '<sid>MoveToCurHeader')
 nnoremap <Plug>Markdown_OpenUrlUnderCursor :call <sid>OpenUrlUnderCursor()<cr>
+nnoremap <Plug>Markdown_EditUrlUnderCursor :call <sid>EditUrlUnderCursor()<cr>
 
 if !get(g:, 'vim_markdown_no_default_key_mappings', 0)
     call <sid>MapNotHasmapto(']]', 'Markdown_MoveToNextHeader')
@@ -607,6 +621,7 @@ if !get(g:, 'vim_markdown_no_default_key_mappings', 0)
     call <sid>MapNotHasmapto(']u', 'Markdown_MoveToParentHeader')
     call <sid>MapNotHasmapto(']c', 'Markdown_MoveToCurHeader')
     call <sid>MapNotHasmapto('gx', 'Markdown_OpenUrlUnderCursor')
+    call <sid>MapNotHasmapto('ge', 'Markdown_EditUrlUnderCursor')
 endif
 
 command! -buffer -range=% HeaderDecrease call s:HeaderDecrease(<line1>, <line2>)


### PR DESCRIPTION
Added a shortcut called `ge` that is similar to `gx` except that it
opens the file under the cursor for editing in Vim. This is particularly
useful when editing markdown that contains relative links to other
markdown files.