### PR TITLE
Highlight mkdLink, mkdInlineURL in Headings

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -79,18 +79,18 @@ syn region mkdLinkTitle matchgroup=mkdDelimiter start=+'+     end=+'+  contained
 syn region mkdLinkTitle matchgroup=mkdDelimiter start=+(+     end=+)+  contained
 
 "HTML headings
-syn region htmlH1       start="^\s*#"                   end="$" contains=@Spell
-syn region htmlH2       start="^\s*##"                  end="$" contains=@Spell
-syn region htmlH3       start="^\s*###"                 end="$" contains=@Spell
-syn region htmlH4       start="^\s*####"                end="$" contains=@Spell
-syn region htmlH5       start="^\s*#####"               end="$" contains=@Spell
-syn region htmlH6       start="^\s*######"              end="$" contains=@Spell
-syn match  htmlH1       /^.\+\n=\+$/ contains=@Spell
-syn match  htmlH2       /^.\+\n-\+$/ contains=@Spell
+syn region htmlH1       start="^\s*#"                   end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH2       start="^\s*##"                  end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH3       start="^\s*###"                 end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH4       start="^\s*####"                end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH5       start="^\s*#####"               end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH6       start="^\s*######"              end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn match  htmlH1       /^.\+\n=\+$/ contains=mkdLink,mkdInlineURL,@Spell
+syn match  htmlH2       /^.\+\n-\+$/ contains=mkdLink,mkdInlineURL,@Spell
 
 "define Markdown groups
 syn match  mkdLineBreak    /  \+$/
-syn region mkdBlockquote   start=/^\s*>/                   end=/$/ contains=mkdLineBreak,@Spell
+syn region mkdBlockquote   start=/^\s*>/                   end=/$/ contains=mkdLink,mkdInlineURL,mkdLineBreak,@Spell
 syn region mkdCode         start=/\(\([^\\]\|^\)\\\)\@<!`/ end=/\(\([^\\]\|^\)\\\)\@<!`/
 syn region mkdCode         start=/\s*``[^`]*/              end=/[^`]*``\s*/
 syn region mkdCode         start=/^\s*\z(`\{3,}\)[^`]*$/   end=/^\s*\z1`*\s*$/

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -320,6 +320,72 @@ Execute (autolink in link text):
   AssertEqual SyntaxOf('b'), 'mkdURL'
   AssertEqual SyntaxOf('c'), 'mkdURL'
 
+Given markdown;
+# [h1link](url)
+
+## [h2link](url)
+
+### [h3link](url)
+
+#### [h4link](url)
+
+##### [h5link](url)
+
+###### [h6link](url)
+
+[h1link_b](url)
+===============
+
+[h2link_b](url)
+---------------
+
+Execute (link in headers):
+  AssertEqual SyntaxOf('h1link'), 'mkdLink'
+  AssertEqual SyntaxOf('h2link'), 'mkdLink'
+  AssertEqual SyntaxOf('h3link'), 'mkdLink'
+  AssertEqual SyntaxOf('h4link'), 'mkdLink'
+  AssertEqual SyntaxOf('h5link'), 'mkdLink'
+  AssertEqual SyntaxOf('h6link'), 'mkdLink'
+  AssertEqual SyntaxOf('h1link_b'), 'mkdLink'
+  AssertEqual SyntaxOf('h2link_b'), 'mkdLink'
+
+Given markdown;
+# http://h1link.foo
+
+## http://h2link.foo
+
+### http://h3link.foo
+
+#### http://h4link.foo
+
+##### http://h5link.foo
+
+###### http://h6link.foo
+
+http://h1link_b.foo
+===================
+
+http://h2link_b.foo
+-------------------
+
+Execute (inline url in headers):
+  AssertEqual SyntaxOf('h1link'), 'mkdInlineURL'
+  AssertEqual SyntaxOf('h2link'), 'mkdInlineURL'
+  AssertEqual SyntaxOf('h3link'), 'mkdInlineURL'
+  AssertEqual SyntaxOf('h4link'), 'mkdInlineURL'
+  AssertEqual SyntaxOf('h5link'), 'mkdInlineURL'
+  AssertEqual SyntaxOf('h6link'), 'mkdInlineURL'
+  AssertEqual SyntaxOf('h1link_b'), 'mkdInlineURL'
+  AssertEqual SyntaxOf('h2link_b'), 'mkdInlineURL'
+
+Given markdown;
+> [a](b)
+> http://foo.bar
+
+Execute (link in blockquote):
+  AssertEqual SyntaxOf('a'), 'mkdLink'
+  AssertEqual SyntaxOf('foo'), 'mkdInlineURL'
+
 # Code Blocks
 
 Given markdown;


### PR DESCRIPTION
Thanks for this great plugin :)

Currently, Link and InlineURL not highlighted in Headings/Blockquotes.
So I tried some fixes for myself and create PR.

![vim-mkd-before](https://cloud.githubusercontent.com/assets/16207504/15244262/47550d74-193b-11e6-90a8-132c6236f99c.png)
![vim-mkd-after](https://cloud.githubusercontent.com/assets/16207504/15244267/4cd5f920-193b-11e6-9e78-346c9674fd27.png)

Heading, bold, etc within blockquotes also reqiure highlighting.