### PR TITLE
Add option to disable foldtext override.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ let g:vim_markdown_folding_style_pythonic = 1
 Level 1 heading which is served as a document title is not folded.
 `g:vim_markdown_folding_level` setting is not active with this fold style.
 
+To prevent foldtext from being set add the following to your `.vimrc`:
+
+```vim
+let g:vim_markdown_override_foldtext = 0
+```
+
 ### Set header folding level
 
 Folding level is a number between 1 and 6. By default, if not specified, it is set to 1.

--- a/after/ftplugin/markdown.vim
+++ b/after/ftplugin/markdown.vim
@@ -150,7 +150,7 @@ let s:vim_markdown_folding_level = get(g:, "vim_markdown_folding_level", 1)
 if !get(g:, "vim_markdown_folding_disabled", 0)
     setlocal foldexpr=Foldexpr_markdown(v:lnum)
     setlocal foldmethod=expr
-    if get(g:, "vim_markdown_folding_style_pythonic", 0)
+    if get(g:, "vim_markdown_folding_style_pythonic", 0) && get(g:, "vim_markdown_override_foldtext", 1)
         setlocal foldtext=Foldtext_markdown()
     endif
 endif

--- a/doc/vim-markdown.txt
+++ b/doc/vim-markdown.txt
@@ -96,6 +96,10 @@ To fold in a style like python-mode [6], add the following to your '.vimrc':
 Level 1 heading which is served as a document title is not folded.
 'g:vim_markdown_folding_level' setting is not active with this fold style.
 
+To prevent foldtext from being overridden, add the following to your '.vimrc':
+
+  let g:vim_markdown_override_foldtext = 0
+
 -------------------------------------------------------------------------------
                                         *vim-markdown-set-header-folding-level*
 Set header folding level ~


### PR DESCRIPTION
Adds the ability to set `g:vim_markdown_override_foldtext = 0` to disable setting foldtext when running with pythonic fold styles.  Handy if you already have a custom foldtext defined and don't want it overwritten.
