### PR TITLE
Option to not require .md extensions in markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ This is super useful for GitLab and GitHub wiki repositories.
 
 Normal behaviour would be that vim-markup required you to do this `[link text](link-url.md)`, but this is not how the Gitlab and GitHub wiki repositories work. So this option adds some consistency between the two. 
 
+### Auto-write when following link
+
+If you follow a link like this `[link text](link-url)` using the "ge" shortcut, this option will automatically save any edits you made before moving you:
+
+```vim
+let g:vim_markdown_autowrite = 1
+```
 
 ## Mappings
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,17 @@ vim-markdown automatically insert the indent. By default, the number of spaces o
 let g:vim_markdown_new_list_item_indent = 2
 ```
 
+### Do not require .md extensions for Markdown links
+
+If you want to have a link like this `[link text](link-url)` and follow it for editing in vim using the "ge" command, but have it open the file "link-url.md" instead of the file "link-url", then use this option:
+
+```vim
+let g:vim_markdown_no_extensions_in_markdown = 1
+```
+This is super useful for GitLab and GitHub wiki repositories.
+
+Normal behaviour would be that vim-markup required you to do this `[link text](link-url.md)`, but this is not how the Gitlab and GitHub wiki repositories work. So this option adds some consistency between the two. 
+
 
 ## Mappings
 

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -582,7 +582,11 @@ if !exists("*s:EditUrlUnderCursor")
   function s:EditUrlUnderCursor()
       let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
       if l:url != ''
-          execute 'edit' l:url
+          if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
+              execute 'edit' fnamemodify(expand('%:~'), ':p:h').'/'.l:url.'.md'
+          else
+              execute 'edit' l:url 
+          endif
       else
           echomsg 'The cursor is not on a link.'
       endif

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -582,6 +582,9 @@ if !exists("*s:EditUrlUnderCursor")
   function s:EditUrlUnderCursor()
       let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
       if l:url != ''
+          if get(g:, 'vim_markdown_autowrite', 0)
+            write
+          endif
           if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
               execute 'edit' fnamemodify(expand('%:~'), ':p:h').'/'.l:url.'.md'
           else


### PR DESCRIPTION
Gitlab uses markdown in an interesting way. If you want to create a link
to the page "linked-to-page" you might do this:

`[Linked To Page Title](linked-to-page)`

And not,

`[Linked To Page Title](linked-to-page.md)`

This change is about having the "ge" command work on wiki links
constructed in this way, and provides consistency between how gitlab
works and vim-markdown works.

It also makes the file open relative to the file you are linking from, which is a sensible change.

The default behaviour is not affected.
