### PR TITLE
Follow named anchors with ge

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,37 @@ This will cause the following to be highlighted using the `cs` filetype syntax.
 
 Default is `['c++=cpp', 'viml=vim', 'bash=sh', 'ini=dosini']`.
 
+### Follow named anchors
+
+This feature allows ge to follow named anchors in links of the form
+`file#anchor` or just `#anchor`, where file may omit the `.md` extension as
+usual. Two variables control its operation:
+
+```vim
+let g:vim_markdown_follow_anchor = 1
+```
+
+This tells vim-markdown whether to attempt to follow a named anchor in a link or
+not. When it is 1, and only if a link can be split in two parts by the pattern
+'#', then the first part is interpreted as the file and the second one as the
+named anchor. This also includes urls of the form `#anchor`, for which the first
+part is considered empty, meaning that the target file is the current one. After
+the file is opened, the anchor will be searched.
+
+Default is `0`.
+
+```vim
+let g:vim_markdown_anchorexpr = "'<<'.v:anchor.'>>'"
+```
+
+This expression will be evaluated substituting `v:anchor` with a quoted string
+that contains the anchor to visit. The result of the evaluation will become the
+real anchor to search in the target file. This is useful in order to convert
+anchors of the form, say, `my-section-title` to searches of the form `My Section
+Title` or `<<my-section-title>>`.
+
+Default is `''`.
+
 ### Syntax extensions
 
 The following options control which syntax extensions will be turned on. They are off by default.

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -581,13 +581,13 @@ endfunction
 if !exists('*s:EditUrlUnderCursor')
     function s:EditUrlUnderCursor()
         let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
-        let l:anchor = ''
         if l:url != ''
             if get(g:, 'vim_markdown_autowrite', 0)
                 write
             endif
+            let l:anchor = ''
             if get(g:, 'vim_markdown_follow_anchor', 0)
-                let l:parts = split(l:url, '#')
+                let l:parts = split(l:url, '#', 1)
                 if len(l:parts) == 2
                     let [l:url, l:anchor] = parts
                     let l:anchorexpr = get(g:, 'vim_markdown_anchorexpr', '')
@@ -598,10 +598,13 @@ if !exists('*s:EditUrlUnderCursor')
                     endif
                 endif
             endif
-            if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
-                let l:url = fnamemodify(expand('%:~'), ':p:h').'/'.l:url.'.md'
+            if l:url != ''
+                if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
+                    let l:url .= '.md'
+                endif
+                let l:url = fnamemodify(expand('%:h').'/'.l:url, ':.')
+                execute 'edit' l:url
             endif
-            execute 'edit' l:url
             if l:anchor != ''
                 silent! execute '/'.l:anchor
             endif

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -578,22 +578,37 @@ endfunction
 
 " We need a definition guard because we invoke 'edit' which will reload this
 " script while this function is running. We must not replace it.
-if !exists("*s:EditUrlUnderCursor")
-  function s:EditUrlUnderCursor()
-      let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
-      if l:url != ''
-          if get(g:, 'vim_markdown_autowrite', 0)
-            write
-          endif
-          if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
-              execute 'edit' fnamemodify(expand('%:~'), ':p:h').'/'.l:url.'.md'
-          else
-              execute 'edit' l:url 
-          endif
-      else
-          echomsg 'The cursor is not on a link.'
-      endif
-  endfunction
+if !exists('*s:EditUrlUnderCursor')
+    function s:EditUrlUnderCursor()
+        let l:url = s:Markdown_GetUrlForPosition(line('.'), col('.'))
+        let l:anchor = ''
+        if l:url != ''
+            if get(g:, 'vim_markdown_autowrite', 0)
+                write
+            endif
+            if get(g:, 'vim_markdown_follow_anchor', 0)
+                let l:parts = split(l:url, '#')
+                if len(l:parts) == 2
+                    let [l:url, l:anchor] = parts
+                    let l:anchorexpr = get(g:, 'vim_markdown_anchorexpr', '')
+                    if l:anchorexpr != ''
+                        let l:anchor = eval(substitute(
+                            \ l:anchorexpr, 'v:anchor',
+                            \ escape('"'.l:anchor.'"', '"'), ''))
+                    endif
+                endif
+            endif
+            if get(g:, 'vim_markdown_no_extensions_in_markdown', 0)
+                let l:url = fnamemodify(expand('%:~'), ':p:h').'/'.l:url.'.md'
+            endif
+            execute 'edit' l:url
+            if l:anchor != ''
+                silent! execute '/'.l:anchor
+            endif
+        else
+            echomsg 'The cursor is not on a link.'
+        endif
+    endfunction
 endif
 
 function! s:VersionAwareNetrwBrowseX(url)


### PR DESCRIPTION
This commit allows ge to follow named anchors in links of the form
file#anchor, where file may omit the .md extension as usual.

Two global variables control the operation of this feature:

    vim_markdown_follow_anchor: a flag that tells vim-markdown whether
    to attempt to follow a named anchor in a link or not. When this is
    1, and only if a link can be split in exactly two parts by the
    pattern '#', then the first part is interpreted as the file and the
    second one as the named anchor. After the file is opened, the anchor
    will be searched.

    vim_markdown_anchorexpr: if available this expression will be
    evaluated substituting v:anchor with a quoted string that contains
    the anchor to visit. The result of the evaluation will become the
    real anchor to search in the target file. This is useful in order to
    convert anchors of the form my-section-title to searches of the form
    My Section Title. It needs to be generic since every markdown
    renderer follows its own conventions to generate "auto-anchors".
    A dummy example: let vim_markdown_anchorexpr = "'<<'.v:anchor"

Note: I've also reformatted EditUrlUnderCursor a bit since it was
violating the 4-space tab and single-quoted string conventions that most
of the rest of the code seems to follow.