### PR TITLE
Make autocommands buffer-local

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -764,10 +764,10 @@ function! s:MarkdownClearSyntaxVariables()
 endfunction
 
 augroup Mkd
-    autocmd!
-    au BufWinEnter * call s:MarkdownRefreshSyntax(1)
-    au BufUnload * call s:MarkdownClearSyntaxVariables()
-    au BufWritePost * call s:MarkdownRefreshSyntax(0)
-    au InsertEnter,InsertLeave * call s:MarkdownRefreshSyntax(0)
-    au CursorHold,CursorHoldI * call s:MarkdownRefreshSyntax(0)
+    autocmd! * <buffer>
+    autocmd BufWinEnter <buffer> call s:MarkdownRefreshSyntax(1)
+    autocmd BufUnload <buffer> call s:MarkdownClearSyntaxVariables()
+    autocmd BufWritePost <buffer> call s:MarkdownRefreshSyntax(0)
+    autocmd InsertEnter,InsertLeave <buffer> call s:MarkdownRefreshSyntax(0)
+    autocmd CursorHold,CursorHoldI <buffer> call s:MarkdownRefreshSyntax(0)
 augroup END


### PR DESCRIPTION
Ensure the commands are executed only for Markdown buffers.

This fixes the autocommands being registered for all buffers, which should not happen. It also generated an unexpected side effect in the case of the `BufUnload` autocommand: deleting another buffer would trigger the autocommand but the current buffer `%` may be an open Markdown file (see `:help BufUnload`), and then `s:MarkdownClearSyntaxVariables()` (introduced in 156e0bfe4e68b01e28aee884bf4e69a34d3e7b1a) would be called in the Markdown buffer, creating issues with the syntax highlight of fenced blocks.