### PR TITLE
Add support for strike through which is supported by GFM

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -145,6 +145,12 @@ if get(g:, 'vim_markdown_math', 0)
   syn region mkdMath start="\\\@<!\$\$" end="\$\$" skip="\\\$" contains=@tex keepend
 endif
 
+" Strike through
+if get(g:, 'vim_markdown_strikethrough', 0)
+    syn region mkdStrike matchgroup=mkdStrike start="\%(\~\~\)"    end="\%(\~\~\)"
+    HtmlHiLink mkdStrike        htmlStrike
+endif
+
 syn cluster mkdNonListItem contains=@htmlTop,htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath
 
 "highlighting for Markdown groups


### PR DESCRIPTION
This is not in standard markdown, but I think it is popular enough.
I do not make it compitible with other syntax(bold, italic, etc.),
this is only a suggestion.

Please forgive my poor English.