### PR TITLE
Specify heading highlight group

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -82,12 +82,12 @@ syn region mkdLinkTitle matchgroup=mkdDelimiter start=+'+     end=+'+  contained
 syn region mkdLinkTitle matchgroup=mkdDelimiter start=+(+     end=+)+  contained
 
 "HTML headings
-syn region htmlH1       start="^\s*#"                   end="$" contains=mkdLink,mkdInlineURL,@Spell
-syn region htmlH2       start="^\s*##"                  end="$" contains=mkdLink,mkdInlineURL,@Spell
-syn region htmlH3       start="^\s*###"                 end="$" contains=mkdLink,mkdInlineURL,@Spell
-syn region htmlH4       start="^\s*####"                end="$" contains=mkdLink,mkdInlineURL,@Spell
-syn region htmlH5       start="^\s*#####"               end="$" contains=mkdLink,mkdInlineURL,@Spell
-syn region htmlH6       start="^\s*######"              end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH1       matchgroup=mkdHeading     start="^\s*#"                   end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH2       matchgroup=mkdHeading     start="^\s*##"                  end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH3       matchgroup=mkdHeading     start="^\s*###"                 end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH4       matchgroup=mkdHeading     start="^\s*####"                end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH5       matchgroup=mkdHeading     start="^\s*#####"               end="$" contains=mkdLink,mkdInlineURL,@Spell
+syn region htmlH6       matchgroup=mkdHeading     start="^\s*######"              end="$" contains=mkdLink,mkdInlineURL,@Spell
 syn match  htmlH1       /^.\+\n=\+$/ contains=mkdLink,mkdInlineURL,@Spell
 syn match  htmlH2       /^.\+\n-\+$/ contains=mkdLink,mkdInlineURL,@Spell
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -1139,19 +1139,19 @@ Given markdown;
 ###### h6
 
 Execute (atx headers):
-  AssertEqual SyntaxOf('# h1 space'), 'htmlH1'
-  AssertEqual SyntaxOf('#h1 nospace'), 'htmlH1'
-  AssertEqual SyntaxOf('#  h1 2 spaces'), 'htmlH1'
-  AssertEqual SyntaxOf('# h1 trailing hash #'), 'htmlH1'
-  AssertEqual SyntaxOf('## h2 space'), 'htmlH2'
-  AssertEqual SyntaxOf('##h2 nospace'), 'htmlH2'
-  AssertEqual SyntaxOf('## h2 trailing hash ##'), 'htmlH2'
-  AssertEqual SyntaxOf('### h3 space'), 'htmlH3'
-  AssertEqual SyntaxOf('###h3 nospace'), 'htmlH3'
-  AssertEqual SyntaxOf('### h3 trailing hash ###'), 'htmlH3'
-  AssertEqual SyntaxOf('#### h4'), 'htmlH4'
-  AssertEqual SyntaxOf('##### h5'), 'htmlH5'
-  AssertEqual SyntaxOf('###### h6'), 'htmlH6'
+  AssertEqual SyntaxOf('# h1 space'), 'mkdHeading'
+  AssertEqual SyntaxOf('#h1 nospace'), 'mkdHeading'
+  AssertEqual SyntaxOf('#  h1 2 spaces'), 'mkdHeading'
+  AssertEqual SyntaxOf('# h1 trailing hash #'), 'mkdHeading'
+  AssertEqual SyntaxOf('## h2 space'), 'mkdHeading'
+  AssertEqual SyntaxOf('##h2 nospace'), 'mkdHeading'
+  AssertEqual SyntaxOf('## h2 trailing hash ##'), 'mkdHeading'
+  AssertEqual SyntaxOf('### h3 space'), 'mkdHeading'
+  AssertEqual SyntaxOf('###h3 nospace'), 'mkdHeading'
+  AssertEqual SyntaxOf('### h3 trailing hash ###'), 'mkdHeading'
+  AssertEqual SyntaxOf('#### h4'), 'mkdHeading'
+  AssertEqual SyntaxOf('##### h5'), 'mkdHeading'
+  AssertEqual SyntaxOf('###### h6'), 'mkdHeading'
 
 Given markdown;
 # h1 before h2
@@ -1161,9 +1161,9 @@ Given markdown;
 # h1 after h2
 
 Execute (atx headers relative positions):
-  AssertEqual SyntaxOf('# h1 before h2'), 'htmlH1'
-  AssertEqual SyntaxOf('## h2 between h1s'), 'htmlH2'
-  AssertEqual SyntaxOf('# h1 after h2'), 'htmlH1'
+  AssertEqual SyntaxOf('# h1 before h2'), 'mkdHeading'
+  AssertEqual SyntaxOf('## h2 between h1s'), 'mkdHeading'
+  AssertEqual SyntaxOf('# h1 after h2'), 'mkdHeading'
 
 Given markdown;
 setex h1
@@ -1214,9 +1214,9 @@ setex h2
 Execute (mixed atx and setex headers):
   AssertEqual SyntaxOf('setex h1 before atx'), 'htmlH1'
   AssertEqual SyntaxOf('==================='), 'htmlH1'
-  AssertEqual SyntaxOf('## atx h2'), 'htmlH2'
-  AssertEqual SyntaxOf('### atx h3'), 'htmlH3'
-  AssertEqual SyntaxOf('# atx h1'), 'htmlH1'
+  AssertEqual SyntaxOf('## atx h2'), 'mkdHeading'
+  AssertEqual SyntaxOf('### atx h3'), 'mkdHeading'
+  AssertEqual SyntaxOf('# atx h1'), 'mkdHeading'
   AssertEqual SyntaxOf('setex h2'), 'htmlH2'
   AssertEqual SyntaxOf('------------------'), 'htmlH2'
 


### PR DESCRIPTION
Specify an `mkdHeading` highlight group so that I can style `#` characters separately.

# Example

### Before

<img width="300" alt="screen shot 2018-04-08 at 9 49 34 am" src="https://user-images.githubusercontent.com/236461/38470077-cc04ae58-3b12-11e8-9737-947aab5cc278.png">

### After (with custom styling)

<img width="300" alt="screen shot 2018-04-08 at 9 51 56 am" src="https://user-images.githubusercontent.com/236461/38470081-d5b91eca-3b12-11e8-9c0c-c57919b276b4.png">
