### PR TITLE
Support YAML frontmatter that ends with "..."

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -115,7 +115,7 @@ syn match  mkdRule         /^\s*_\s\{0,1}_\s\{0,1}_\(_\|\s\)*$/
 " YAML frontmatter
 if get(g:, 'vim_markdown_frontmatter', 0)
   syn include @yamlTop syntax/yaml.vim
-  syn region Comment matchgroup=mkdDelimiter start="\%^---$" end="^---$" contains=@yamlTop keepend
+  syn region Comment matchgroup=mkdDelimiter start="\%^---$" end="^\(---\|...\)$" contains=@yamlTop keepend
   unlet! b:current_syntax
 endif
 


### PR DESCRIPTION
Currently, frontmatter that looks like this:

```
---
foo: bar
...

# some Markdown
```

doesn't work properly, as the `...` doesn't end the YAML syntax highlighting. This PR corrects that behaviour, so now either `---` or `...` can end a YAML frontmatter block.

There should be no backwards compatibility issues here, since a line containing only `...` is not valid YAML apart from marking the end of a document.

Fixes #295.