### PR TITLE
Add option to disable automatic bullet insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,22 @@ If you would like to use a file extension other than `.md` you may do so using t
 let g:vim_markdown_auto_extension_ext = 'txt'
 ```
 
+### Do not automatically insert bulletpoints
+
+Automatically inserting bulletpoints can lead to problems when wrapping text
+(see issue #232 for details), so it can be disabled:
+
+```vim
+let g:vim_markdown_auto_insert_bullets = 0
+```
+
+In that case, you probably also want to set the new list item indent to 0 as
+well, or you will have to remove an indent each time you add a new list item:
+
+```vim
+let g:vim_markdown_new_list_item_indent = 0
+```
+
 ## Mappings
 
 The following work on normal and visual modes:

--- a/indent/markdown.vim
+++ b/indent/markdown.vim
@@ -5,15 +5,15 @@ setlocal indentexpr=GetMarkdownIndent()
 setlocal nolisp
 setlocal autoindent
 
-" Automatically insert bullets
-setlocal formatoptions+=r
-" Do not automatically insert bullets when auto-wrapping with text-width
-setlocal formatoptions-=c
-" Accept various markers as bullets
-setlocal comments=b:*,b:+,b:-
-
 " Automatically continue blockquote on line break
-setlocal comments+=b:>
+setlocal formatoptions+=r
+setlocal comments=b:>
+if get(g:, "vim_markdown_auto_insert_bullets", 1)
+    " Do not automatically insert bullets when auto-wrapping with text-width
+    setlocal formatoptions-=c
+    " Accept various markers as bullets
+    setlocal comments+=b:*,b:+,b:-
+endif
 
 " Only define the function once
 if exists("*GetMarkdownIndent") | finish | endif


### PR DESCRIPTION
This PR adds a new option, `g:vim_markdown_auto_insert_bullets`, that disables the automatic bulletpoint insertion which is causing issues with text wrapping. The option is enabled by default to preserve backwards compatibility.

With the option enabled (the default), the behaviour is as before. If the option is disabled, bulletpoints are no longer automatically inserted, either when pressing `<Enter>` or when wrapping text with `gq`. Behaviour of blockquotes is not changed.

The new documentation for the option also suggests to set the new list item indent (`vim_markdown_new_list_item_indent`) to 0, as otherwise you will have to erase the indent each time you want to add a new bulletpoint.

Fixes #232. (Also see commit 642730fccce7e78c995389f3c430747d266efa96, from which this PR was inspired.)