### PR TITLE
Fix detection of YAML frontmatter ending with "..."

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -115,7 +115,7 @@ syn match  mkdRule         /^\s*_\s\{0,1}_\s\{0,1}_\(_\|\s\)*$/
 " YAML frontmatter
 if get(g:, 'vim_markdown_frontmatter', 0)
   syn include @yamlTop syntax/yaml.vim
-  syn region Comment matchgroup=mkdDelimiter start="\%^---$" end="^\(---\|...\)$" contains=@yamlTop keepend
+  syn region Comment matchgroup=mkdDelimiter start="\%^---$" end="^\(---\|\.\.\.\)$" contains=@yamlTop keepend
   unlet! b:current_syntax
 endif
 


### PR DESCRIPTION
PR #374 introduced a bug which would cause any line containing exactly three characters to be highlighted as the end of a YAML frontmatter block; this commit fixes that, so that only three dots will end the block.