### PR TITLE
ftplugin: syntax highlighting for fts *markdown*

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -768,13 +768,13 @@ endfunction
 
 
 function! s:MarkdownRefreshSyntax(force)
-    if &filetype == 'markdown' && line('$') > 1
+    if &filetype =~ 'markdown' && line('$') > 1
         call s:MarkdownHighlightSources(a:force)
     endif
 endfunction
 
 function! s:MarkdownClearSyntaxVariables()
-    if &filetype == 'markdown'
+    if &filetype =~ 'markdown'
         unlet! b:mkd_included_filetypes
     endif
 endfunction


### PR DESCRIPTION
I personally have this inside my `ftplugin/markdown.vim` file:

```vim
au FileType markdown exec 'set filetype=' . &filetype . ".html"
```

This is useful so that I can have html snippets inside markdown files. But, I don't want to lose my fenced code blocks syntax highlighting.