### PR TITLE
Prevent repeated sourcing of syntax

### DIFF
--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -1,3 +1,8 @@
+if !has('patch-7.4.480')
+    " Before this patch, vim used modula2 for .md.
+    au! filetypedetect BufRead,BufNewFile *.md
+endif
+
 " markdown filetype file
-au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn} set filetype=markdown
-au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn}.{des3,des,bf,bfa,aes,idea,cast,rc2,rc4,rc5,desx} set filetype=markdown
+au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn} setfiletype markdown
+au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn}.{des3,des,bf,bfa,aes,idea,cast,rc2,rc4,rc5,desx} setfiletype markdown


### PR DESCRIPTION
**Bug**: Using `vim --startuptime ~/time.log name.md` would show multiple
sourcing of syntax/markdown.vim indicating unnecessary startup cost.

**Cause**: As of vim/vim@7d76c804af900ba6dcc4b1e45373ccab3418c6b2, vim uses
.md for markdown instead of modula2. Since vim-markdown was using `set
filetype`, it was sourcing the files a second time after vim's runtime
files had already set the filetype.

**Resolution**: Using `setfiletype` prevents this double sourcing. To remain
backwards compatible, we remove the .md filetype detection for modula2
on old versions.

Related to sheerun/vim-polyglot#290.

Tested .md ftdetection with vim 7.4.052 and 8.1.527.