### PR TITLE
Syntax: Fix strikethrough

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -155,7 +155,7 @@ if get(g:, 'vim_markdown_strikethrough', 0)
     HtmlHiLink mkdStrike        htmlStrike
 endif
 
-syn cluster mkdNonListItem contains=@htmlTop,htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath
+syn cluster mkdNonListItem contains=@htmlTop,htmlItalic,htmlBold,htmlBoldItalic,mkdFootnotes,mkdInlineURL,mkdLink,mkdLinkDef,mkdLineBreak,mkdBlockquote,mkdCode,mkdRule,htmlH1,htmlH2,htmlH3,htmlH4,htmlH5,htmlH6,mkdMath,htmlStrike
 
 "highlighting for Markdown groups
 HtmlHiLink mkdString        String


### PR DESCRIPTION
Why
---
Strikethrough was only matching if the strikethrough happened to occur in a list

How
---
Add `mkdStrike` and `htmlStrike` to `mkdNonListItem` cluster