### PR TITLE
Testing fix

### DIFF
--- a/test/vimrc
+++ b/test/vimrc
@@ -4,6 +4,8 @@ set rtp+=../build/tabular/
 set rtp+=../build/vim-toml/
 set rtp+=../build/vim-json/
 set rtp+=../build/vader.vim/
+set rtp-=~/.vim
+set rtp-=~/.vim/after
 let $LANG='en_US'
 filetype on
 filetype plugin on


### PR DESCRIPTION
The default value of runtimepath includes ~/.vim and ~/.vim/after.  Configuration in those directories can interfere with tests.  Remove those directories from runtimepath to make the tests hermetic.
