### PR TITLE
Folding fix

### DIFF
--- a/after/ftplugin/markdown.vim
+++ b/after/ftplugin/markdown.vim
@@ -151,10 +151,20 @@ let b:fenced_block = 0
 let b:front_matter = 0
 let s:vim_markdown_folding_level = get(g:, "vim_markdown_folding_level", 1)
 
-if !get(g:, "vim_markdown_folding_disabled", 0)
-    setlocal foldexpr=Foldexpr_markdown(v:lnum)
-    setlocal foldmethod=expr
-    if get(g:, "vim_markdown_folding_style_pythonic", 0) && get(g:, "vim_markdown_override_foldtext", 1)
-        setlocal foldtext=Foldtext_markdown()
-    endif
-endif
+function! s:MarkdownSetupFolding()
+  if !get(g:, "vim_markdown_folding_disabled", 0)
+      setlocal foldexpr=Foldexpr_markdown(v:lnum)
+      setlocal foldmethod=expr
+      if get(g:, "vim_markdown_folding_style_pythonic", 0) && get(g:, "vim_markdown_override_foldtext", 1)
+          setlocal foldtext=Foldtext_markdown()
+      endif
+  endif
+endfunction
+call s:MarkdownSetupFolding()
+augroup Mkd
+    " These autocmds need to be kept in sync with the autocmds calling
+    " s:MarkdownRefreshSyntax in ftplugin/markdown.vim.
+    autocmd BufWinEnter,BufWritePost <buffer> call s:MarkdownSetupFolding()
+    autocmd InsertEnter,InsertLeave <buffer> call s:MarkdownSetupFolding()
+    autocmd CursorHold,CursorHoldI <buffer> call s:MarkdownSetupFolding()
+augroup END

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -780,6 +780,8 @@ function! s:MarkdownClearSyntaxVariables()
 endfunction
 
 augroup Mkd
+    " These autocmd calling s:MarkdownRefreshSyntax need to be kept in sync with
+    " the autocmds calling s:MarkdownSetupFolding in after/ftplugin/markdown.vim.
     autocmd! * <buffer>
     autocmd BufWinEnter <buffer> call s:MarkdownRefreshSyntax(1)
     autocmd BufUnload <buffer> call s:MarkdownClearSyntaxVariables()


### PR DESCRIPTION
When syntax highlighting is enabled for fenced code blocks, the syntax
highlighting of the language in the code block can overwrite folding
configuration, breaking Markdown folding.  Reinitialise Markdown folding
configuration every time syntax highlighting is refreshed to ensure that
Markdown folding works.

Lightly tested manually with files where folding was unreliable.