### PR TITLE
Fix double code quotes with backslashes

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -99,7 +99,7 @@ syn match  htmlH2       /^.\+\n-\+$/ contains=mkdLink,mkdInlineURL,@Spell
 syn match  mkdLineBreak    /  \+$/
 syn region mkdBlockquote   start=/^\s*>/                   end=/$/ contains=mkdLink,mkdInlineURL,mkdLineBreak,@Spell
 execute 'syn region mkdCode matchgroup=mkdCodeDelimiter start=/\(\([^\\]\|^\)\\\)\@<!`/                     end=/`/'  . s:concealcode
-execute 'syn region mkdCode matchgroup=mkdCodeDelimiter start=/\(\([^\\]\|^\)\\\)\@<!``/ skip=/[^`]`[^`]/   end=/\(\([^\\]\|^\)\\\)\@<!``/' . s:concealcode
+execute 'syn region mkdCode matchgroup=mkdCodeDelimiter start=/\(\([^\\]\|^\)\\\)\@<!``/ skip=/[^`]`[^`]/   end=/``/' . s:concealcode
 execute 'syn region mkdCode matchgroup=mkdCodeDelimiter start=/^\s*\z(`\{3,}\)[^`]*$/                       end=/^\s*\z1`*\s*$/'            . s:concealcode
 execute 'syn region mkdCode matchgroup=mkdCodeDelimiter start=/\(\([^\\]\|^\)\\\)\@<!\~\~/  end=/\(\([^\\]\|^\)\\\)\@<!\~\~/'               . s:concealcode
 execute 'syn region mkdCode matchgroup=mkdCodeDelimiter start=/^\s*\z(\~\{3,}\)\s*[0-9A-Za-z_+-]*\s*$/      end=/^\s*\z1\~*\s*$/'           . s:concealcode

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -899,6 +899,15 @@ Execute (code quotes not escaped ending with backslash):
   AssertEqual SyntaxOf('c\'), 'mkdCode'
   AssertNotEqual SyntaxOf('d'), 'mkdCode'
 
+Given markdown;
+``a\`` b ``c`\`1`` d
+
+Execute (double code quotes not escaped ending with backslash):
+  AssertEqual SyntaxOf('a\'), 'mkdCode'
+  AssertNotEqual SyntaxOf('b'), 'mkdCode'
+  AssertEqual SyntaxOf('c`\\`1'), 'mkdCode'
+  AssertNotEqual SyntaxOf('d'), 'mkdCode'
+
 # Math
 
 Given markdown;


### PR DESCRIPTION
This is a follow-up of https://github.com/plasticboy/vim-markdown/commit/5c9ce6b5230654c73d3bc3311f9dff7c4404f228 which fixed #311.

The following is the content for test and actual GitHub rendering:
``` markdown
``a\`` b ``c`\`1`` d
```
``a\`` b ``c`\`1`` d