### PR TITLE
Generate IDs of global variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,12 @@ doc: build/html2vimdoc build/vim-tools
 		    -e "s/^- '([^']{1,2})':.*/ \*vim-markdown-\1\*/" -e "# short command" \
 		    -e ":a" -e "s/^(.{1,78})$$/ \1/" -e "ta" -e "# align right" \
 		    -e "G" -e "# append the matched line after the command reference" \
+		    -e "}" \
+		    -e "/^- '[^']*'$$/ {" \
+		    -e "h" -e "# save the matched line to the hold space" \
+		    -e "s/^- '([^']*)'$$/ \*\1\*/" -e "# make global variable reference" \
+		    -e ":g" -e "s/^(.{1,78})$$/ \1/" -e "tg" -e "# align right" \
+		    -e "G" -e "# append the matched line after the global variable reference" \
 		    -e "}" > doc/vim-markdown.txt && rm -f doc/tmp.md
 
 .PHONY: doc

--- a/README.md
+++ b/README.md
@@ -88,154 +88,146 @@ Try `:help concealcursor` and `:help conceallevel` for details.
 
 ### Disable Folding
 
-Add the following line to your `.vimrc` to disable the folding configuration:
+-   `g:vim_markdown_folding_disabled`
 
-```vim
-let g:vim_markdown_folding_disabled = 1
-```
+    Add the following line to your `.vimrc` to disable the folding configuration:
 
-This option only controls Vim Markdown specific folding configuration.
+        let g:vim_markdown_folding_disabled = 1
 
-To enable/disable folding use Vim's standard folding configuration.
+    This option only controls Vim Markdown specific folding configuration.
 
-```vim
-set [no]foldenable
-```
+    To enable/disable folding use Vim's standard folding configuration.
+
+        set [no]foldenable
 
 ### Change fold style
 
-To fold in a style like [python-mode](https://github.com/klen/python-mode), add the following to your `.vimrc`:
+-   `g:vim_markdown_folding_style_pythonic`
 
-```vim
-let g:vim_markdown_folding_style_pythonic = 1
-```
+    To fold in a style like [python-mode](https://github.com/klen/python-mode), add the following to your `.vimrc`:
 
-Level 1 heading which is served as a document title is not folded.
-`g:vim_markdown_folding_level` setting is not active with this fold style.
+        let g:vim_markdown_folding_style_pythonic = 1
 
-To prevent foldtext from being set add the following to your `.vimrc`:
+    Level 1 heading which is served as a document title is not folded.
+    `g:vim_markdown_folding_level` setting is not active with this fold style.
 
-```vim
-let g:vim_markdown_override_foldtext = 0
-```
+-   `g:vim_markdown_override_foldtext`
+
+    To prevent foldtext from being set add the following to your `.vimrc`:
+
+        let g:vim_markdown_override_foldtext = 0
 
 ### Set header folding level
 
-Folding level is a number between 1 and 6. By default, if not specified, it is set to 1.
+-   `g:vim_markdown_folding_level`
 
-```vim
-let g:vim_markdown_folding_level = 6
-```
+    Folding level is a number between 1 and 6. By default, if not specified, it is set to 1.
 
-Tip: it can be changed on the fly with:
+        let g:vim_markdown_folding_level = 6
 
-```vim
-:let g:vim_markdown_folding_level = 1
-:edit
-```
+    Tip: it can be changed on the fly with:
+
+        :let g:vim_markdown_folding_level = 1
+        :edit
 
 ### Disable Default Key Mappings
 
-Add the following line to your `.vimrc` to disable default key mappings:
+-   `g:vim_markdown_no_default_key_mappings`
 
-```vim
-let g:vim_markdown_no_default_key_mappings = 1
-```
+    Add the following line to your `.vimrc` to disable default key mappings:
 
-You can also map them by yourself with `<Plug>` mappings.
+        let g:vim_markdown_no_default_key_mappings = 1
+
+    You can also map them by yourself with `<Plug>` mappings.
 
 ### Enable TOC window auto-fit
 
-Allow for the TOC window to auto-fit when it's possible for it to shrink.
-It never increases its default size (half screen), it only shrinks.
+-   `g:vim_markdown_toc_autofit`
 
-```vim
-let g:vim_markdown_toc_autofit = 1
-```
+    Allow for the TOC window to auto-fit when it's possible for it to shrink.
+    It never increases its default size (half screen), it only shrinks.
+
+        let g:vim_markdown_toc_autofit = 1
 
 ### Text emphasis restriction to single-lines
 
-By default text emphasis works across multiple lines until a closing token is found. However, it's possible to restrict text emphasis to a single line (i.e., for it to be applied a closing token must be found on the same line). To do so:
+-   `g:vim_markdown_emphasis_multiline`
 
-```vim
-let g:vim_markdown_emphasis_multiline = 0
-```
+    By default text emphasis works across multiple lines until a closing token is found. However, it's possible to restrict text emphasis to a single line (i.e., for it to be applied a closing token must be found on the same line). To do so:
+
+        let g:vim_markdown_emphasis_multiline = 0
 
 ### Syntax Concealing
 
-Concealing is set for some syntax.
+-   `g:vim_markdown_conceal`
 
-For example, conceal `[link text](link url)` as just `link text`.
-Also, `_italic_` and `*italic*` will conceal to just _italic_.
-Similarly `__bold__`, `**bold**`, `___italic bold___`, and `***italic bold***`
-will conceal to just __bold__, **bold**, ___italic bold___, and ***italic bold*** respectively.
+    Concealing is set for some syntax.
 
-To enable conceal use Vim's standard conceal configuration.
+    For example, conceal `[link text](link url)` as just `link text`.
+    Also, `_italic_` and `*italic*` will conceal to just _italic_.
+    Similarly `__bold__`, `**bold**`, `___italic bold___`, and `***italic bold***`
+    will conceal to just __bold__, **bold**, ___italic bold___, and ***italic bold*** respectively.
 
-```vim
-set conceallevel=2
-```
+    To enable conceal use Vim's standard conceal configuration.
 
-To disable conceal regardless of `conceallevel` setting, add the following to your `.vimrc`:
+        set conceallevel=2
 
-```vim
-let g:vim_markdown_conceal = 0
-```
+    To disable conceal regardless of `conceallevel` setting, add the following to your `.vimrc`:
 
-To disable math conceal with LaTeX math syntax enabled, add the following to your `.vimrc`:
+        let g:vim_markdown_conceal = 0
 
-```vim
-let g:tex_conceal = ""
-let g:vim_markdown_math = 1
-```
+    To disable math conceal with LaTeX math syntax enabled, add the following to your `.vimrc`:
+
+        let g:tex_conceal = ""
+        let g:vim_markdown_math = 1
 
 ### Fenced code block languages
 
-You can use filetype name as fenced code block languages for syntax highlighting.
-If you want to use different name from filetype, you can add it in your `.vimrc` like so:
+-   `g:vim_markdown_fenced_languages`
 
-```vim
-let g:vim_markdown_fenced_languages = ['csharp=cs']
-```
+    You can use filetype name as fenced code block languages for syntax highlighting.
+    If you want to use different name from filetype, you can add it in your `.vimrc` like so:
 
-This will cause the following to be highlighted using the `cs` filetype syntax.
+        let g:vim_markdown_fenced_languages = ['csharp=cs']
 
-    ```csharp
-    ...
-    ```
+    This will cause the following to be highlighted using the `cs` filetype syntax.
 
-Default is `['c++=cpp', 'viml=vim', 'bash=sh', 'ini=dosini']`.
+        ```csharp
+        ...
+        ```
+
+    Default is `['c++=cpp', 'viml=vim', 'bash=sh', 'ini=dosini']`.
 
 ### Follow named anchors
 
-This feature allows the `ge` command to follow named anchors in links of the form
-`file#anchor` or just `#anchor`, where file may omit the `.md` extension as
-usual. Two variables control its operation:
+-   `g:vim_markdown_follow_anchor`
 
-```vim
-let g:vim_markdown_follow_anchor = 1
-```
+    This feature allows the `ge` command to follow named anchors in links of the form
+    `file#anchor` or just `#anchor`, where file may omit the `.md` extension as
+    usual. Two variables control its operation:
 
-This tells vim-markdown whether to attempt to follow a named anchor in a link or
-not. When it is 1, and only if a link can be split in two parts by the pattern
-'#', then the first part is interpreted as the file and the second one as the
-named anchor. This also includes urls of the form `#anchor`, for which the first
-part is considered empty, meaning that the target file is the current one. After
-the file is opened, the anchor will be searched.
+        let g:vim_markdown_follow_anchor = 1
 
-Default is `0`.
+    This tells vim-markdown whether to attempt to follow a named anchor in a link or
+    not. When it is 1, and only if a link can be split in two parts by the pattern
+    '#', then the first part is interpreted as the file and the second one as the
+    named anchor. This also includes urls of the form `#anchor`, for which the first
+    part is considered empty, meaning that the target file is the current one. After
+    the file is opened, the anchor will be searched.
 
-```vim
-let g:vim_markdown_anchorexpr = "'<<'.v:anchor.'>>'"
-```
+    Default is `0`.
 
-This expression will be evaluated substituting `v:anchor` with a quoted string
-that contains the anchor to visit. The result of the evaluation will become the
-real anchor to search in the target file. This is useful in order to convert
-anchors of the form, say, `my-section-title` to searches of the form `My Section
-Title` or `<<my-section-title>>`.
+-   `g:vim_markdown_anchorexpr`
 
-Default is `''`.
+        let g:vim_markdown_anchorexpr = "'<<'.v:anchor.'>>'"
+
+    This expression will be evaluated substituting `v:anchor` with a quoted string
+    that contains the anchor to visit. The result of the evaluation will become the
+    real anchor to search in the target file. This is useful in order to convert
+    anchors of the form, say, `my-section-title` to searches of the form `My Section
+    Title` or `<<my-section-title>>`.
+
+    Default is `''`.
 
 ### Syntax extensions
 
@@ -243,119 +235,114 @@ The following options control which syntax extensions will be turned on. They ar
 
 #### LaTeX math
 
-Used as `$x^2$`, `$$x^2$$`, escapable as `\$x\$` and `\$\$x\$\$`.
+-   `g:vim_markdown_math`
 
-```vim
-let g:vim_markdown_math = 1
-```
+    Used as `$x^2$`, `$$x^2$$`, escapable as `\$x\$` and `\$\$x\$\$`.
+
+        let g:vim_markdown_math = 1
 
 #### YAML Front Matter
 
-Highlight YAML front matter as used by Jekyll or [Hugo](https://gohugo.io/content/front-matter/).
+-   `g:vim_markdown_frontmatter`
 
-```vim
-let g:vim_markdown_frontmatter = 1
-```
+    Highlight YAML front matter as used by Jekyll or [Hugo](https://gohugo.io/content/front-matter/).
+
+        let g:vim_markdown_frontmatter = 1
 
 #### TOML Front Matter
 
-Highlight TOML front matter as used by [Hugo](https://gohugo.io/content/front-matter/).
+-   `g:vim_markdown_toml_frontmatter`
 
-TOML syntax highlight requires [vim-toml](https://github.com/cespare/vim-toml).
+    Highlight TOML front matter as used by [Hugo](https://gohugo.io/content/front-matter/).
 
-```vim
-let g:vim_markdown_toml_frontmatter = 1
-```
+    TOML syntax highlight requires [vim-toml](https://github.com/cespare/vim-toml).
+
+        let g:vim_markdown_toml_frontmatter = 1
 
 #### JSON Front Matter
 
-Highlight JSON front matter as used by [Hugo](https://gohugo.io/content/front-matter/).
+-   `g:vim_markdown_json_frontmatter`
 
-JSON syntax highlight requires [vim-json](https://github.com/elzr/vim-json).
+    Highlight JSON front matter as used by [Hugo](https://gohugo.io/content/front-matter/).
 
-```vim
-let g:vim_markdown_json_frontmatter = 1
-```
+    JSON syntax highlight requires [vim-json](https://github.com/elzr/vim-json).
+
+        let g:vim_markdown_json_frontmatter = 1
 
 #### Strikethrough
 
-Strikethrough uses two tildes. `~~Scratch this.~~`
+-   `g:vim_markdown_strikethrough`
 
-```vim
-let g:vim_markdown_strikethrough = 1
-```
+    Strikethrough uses two tildes. `~~Scratch this.~~`
+
+        let g:vim_markdown_strikethrough = 1
 
 ### Adjust new list item indent
 
-You can adjust a new list indent. For example, you insert a single line like below:
+-   `g:vim_markdown_new_list_item_indent`
 
-```
-* item1
-```
+    You can adjust a new list indent. For example, you insert a single line like below:
 
-Then if you type `o` to insert new line in vim and type `* item2`, the result will be:
+        * item1
 
-```
-* item1
-    * item2
-```
+    Then if you type `o` to insert new line in vim and type `* item2`, the result will be:
 
-vim-markdown automatically insert the indent. By default, the number of spaces of indent is 4. If you'd like to change the number as 2, just write:
+        * item1
+            * item2
 
-```vim
-let g:vim_markdown_new_list_item_indent = 2
-```
+    vim-markdown automatically insert the indent. By default, the number of spaces of indent is 4. If you'd like to change the number as 2, just write:
+
+        let g:vim_markdown_new_list_item_indent = 2
 
 ### Do not require .md extensions for Markdown links
 
-If you want to have a link like this `[link text](link-url)` and follow it for editing in vim using the `ge` command, but have it open the file "link-url.md" instead of the file "link-url", then use this option:
+-   `g:vim_markdown_no_extensions_in_markdown`
 
-```vim
-let g:vim_markdown_no_extensions_in_markdown = 1
-```
-This is super useful for GitLab and GitHub wiki repositories.
+    If you want to have a link like this `[link text](link-url)` and follow it for editing in vim using the `ge` command, but have it open the file "link-url.md" instead of the file "link-url", then use this option:
 
-Normal behaviour would be that vim-markup required you to do this `[link text](link-url.md)`, but this is not how the Gitlab and GitHub wiki repositories work. So this option adds some consistency between the two. 
+        let g:vim_markdown_no_extensions_in_markdown = 1
+
+    This is super useful for GitLab and GitHub wiki repositories.
+
+    Normal behaviour would be that vim-markup required you to do this `[link text](link-url.md)`, but this is not how the Gitlab and GitHub wiki repositories work. So this option adds some consistency between the two.
 
 ### Auto-write when following link
 
-If you follow a link like this `[link text](link-url)` using the `ge` shortcut, this option will automatically save any edits you made before moving you:
+-   `g:vim_markdown_autowrite`
 
-```vim
-let g:vim_markdown_autowrite = 1
-```
+    If you follow a link like this `[link text](link-url)` using the `ge` shortcut, this option will automatically save any edits you made before moving you:
+
+        let g:vim_markdown_autowrite = 1
 
 ### Change default file extension
 
-If you would like to use a file extension other than `.md` you may do so using the `vim_markdown_auto_extension_ext` variable:
+-   `g:vim_markdown_auto_extension_ext`
 
-```vim
-let g:vim_markdown_auto_extension_ext = 'txt'
-```
+    If you would like to use a file extension other than `.md` you may do so using the `vim_markdown_auto_extension_ext` variable:
+
+        let g:vim_markdown_auto_extension_ext = 'txt'
 
 ### Do not automatically insert bulletpoints
 
-Automatically inserting bulletpoints can lead to problems when wrapping text
-(see issue #232 for details), so it can be disabled:
+-   `g:vim_markdown_auto_insert_bullets`
 
-```vim
-let g:vim_markdown_auto_insert_bullets = 0
-```
+    Automatically inserting bulletpoints can lead to problems when wrapping text
+    (see issue #232 for details), so it can be disabled:
 
-In that case, you probably also want to set the new list item indent to 0 as
-well, or you will have to remove an indent each time you add a new list item:
+        let g:vim_markdown_auto_insert_bullets = 0
 
-```vim
-let g:vim_markdown_new_list_item_indent = 0
-```
+    In that case, you probably also want to set the new list item indent to 0 as
+    well, or you will have to remove an indent each time you add a new list item:
+
+        let g:vim_markdown_new_list_item_indent = 0
 
 ### Change how to open new files
 
-By default when following a link the target file will be opened in your current buffer.  This behavior can change if you prefer using splits or tabs by using the `vim_markdown_edit_url_in` variable.  Possible values are `tab`, `vsplit`, `hsplit`, `current` opening in a new tab, vertical split, horizontal split, and current buffer respectively.  Defaults to current buffer if not set:
+-   `g:vim_markdown_edit_url_in`
 
-```vim
-let g:vim_markdown_edit_url_in = 'tab'
-```
+    By default when following a link the target file will be opened in your current buffer.  This behavior can change if you prefer using splits or tabs by using the `vim_markdown_edit_url_in` variable.  Possible values are `tab`, `vsplit`, `hsplit`, `current` opening in a new tab, vertical split, horizontal split, and current buffer respectively.  Defaults to current buffer if not set:
+
+        let g:vim_markdown_edit_url_in = 'tab'
 
 ## Mappings
 

--- a/doc/vim-markdown.txt
+++ b/doc/vim-markdown.txt
@@ -52,7 +52,7 @@ and extensions.
                                                     *vim-markdown-installation*
 Installation ~
 
-If you use Vundle [2], add the following line to your '~/.vimrc':
+If you use Vundle [2], add the following lines to your '~/.vimrc':
 >
   Plugin 'godlygeek/tabular'
   Plugin 'plasticboy/vim-markdown'
@@ -133,159 +133,187 @@ Options ~
 
 -------------------------------------------------------------------------------
                                                  *vim-markdown-disable-folding*
-                                              *g:vim_markdown_folding_disabled*
 Disable Folding ~
 
-Add the following line to your '.vimrc' to disable the folding configuration:
+                                              *g:vim_markdown_folding_disabled*
+- 'g:vim_markdown_folding_disabled'
+
+  Add the following line to your '.vimrc' to disable the folding
+  configuration:
 >
   let g:vim_markdown_folding_disabled = 1
 <
-This option only controls Vim Markdown specific folding configuration.
+  This option only controls Vim Markdown specific folding configuration.
 
-To enable/disable folding use Vim's standard folding configuration.
+  To enable/disable folding use Vim's standard folding configuration.
 >
   set [no]foldenable
 <
 -------------------------------------------------------------------------------
                                                *vim-markdown-change-fold-style*
-                                        *g:vim_markdown_folding_style_pythonic*
-                                             *g:vim_markdown_override_foldtext*
 Change fold style ~
 
-To fold in a style like python-mode [6], add the following to your '.vimrc':
+                                        *g:vim_markdown_folding_style_pythonic*
+- 'g:vim_markdown_folding_style_pythonic'
+
+  To fold in a style like python-mode [6], add the following to your
+  '.vimrc':
 >
   let g:vim_markdown_folding_style_pythonic = 1
 <
-Level 1 heading which is served as a document title is not folded.
-'g:vim_markdown_folding_level' setting is not active with this fold style.
+  Level 1 heading which is served as a document title is not folded.
+  'g:vim_markdown_folding_level' setting is not active with this fold style.
 
-To prevent foldtext from being set add the following to your '.vimrc':
+                                             *g:vim_markdown_override_foldtext*
+- 'g:vim_markdown_override_foldtext'
+
+  To prevent foldtext from being set add the following to your '.vimrc':
 >
   let g:vim_markdown_override_foldtext = 0
 <
 -------------------------------------------------------------------------------
                                         *vim-markdown-set-header-folding-level*
-                                                 *g:vim_markdown_folding_level*
 Set header folding level ~
 
-Folding level is a number between 1 and 6. By default, if not specified, it is
-set to 1.
+                                                 *g:vim_markdown_folding_level*
+- 'g:vim_markdown_folding_level'
+
+  Folding level is a number between 1 and 6. By default, if not specified, it
+  is set to 1.
 >
   let g:vim_markdown_folding_level = 6
 <
-Tip: it can be changed on the fly with:
+  Tip: it can be changed on the fly with:
 >
   :let g:vim_markdown_folding_level = 1
   :edit
 <
 -------------------------------------------------------------------------------
                                     *vim-markdown-disable-default-key-mappings*
-                                       *g:vim_markdown_no_default_key_mappings*
 Disable Default Key Mappings ~
 
-Add the following line to your '.vimrc' to disable default key mappings:
+                                       *g:vim_markdown_no_default_key_mappings*
+- 'g:vim_markdown_no_default_key_mappings'
+
+  Add the following line to your '.vimrc' to disable default key mappings:
 >
   let g:vim_markdown_no_default_key_mappings = 1
 <
-You can also map them by yourself with '<Plug>' mappings.
+  You can also map them by yourself with '<Plug>' mappings.
 
 -------------------------------------------------------------------------------
                                       *vim-markdown-enable-toc-window-auto-fit*
-                                                   *g:vim_markdown_toc_autofit*
 Enable TOC window auto-fit ~
 
-Allow for the TOC window to auto-fit when it's possible for it to shrink. It
-never increases its default size (half screen), it only shrinks.
+                                                   *g:vim_markdown_toc_autofit*
+- 'g:vim_markdown_toc_autofit'
+
+  Allow for the TOC window to auto-fit when it's possible for it to shrink.
+  It never increases its default size (half screen), it only shrinks.
 >
   let g:vim_markdown_toc_autofit = 1
 <
 -------------------------------------------------------------------------------
                        *vim-markdown-text-emphasis-restriction-to-single-lines*
-                                            *g:vim_markdown_emphasis_multiline*
 Text emphasis restriction to single-lines ~
 
-By default text emphasis works across multiple lines until a closing token is
-found. However, it's possible to restrict text emphasis to a single line (i.e.,
-for it to be applied a closing token must be found on the same line). To do so:
+                                            *g:vim_markdown_emphasis_multiline*
+- 'g:vim_markdown_emphasis_multiline'
+
+  By default text emphasis works across multiple lines until a closing token
+  is found. However, it's possible to restrict text emphasis to a single line
+  (i.e., for it to be applied a closing token must be found on the same
+  line). To do so:
 >
   let g:vim_markdown_emphasis_multiline = 0
 <
 -------------------------------------------------------------------------------
                                                *vim-markdown-syntax-concealing*
-                                                       *g:vim_markdown_conceal*
 Syntax Concealing ~
 
-Concealing is set for some syntax.
+                                                       *g:vim_markdown_conceal*
+- 'g:vim_markdown_conceal'
 
-For example, conceal '[link text](link url)' as just 'link text'. Also,
-'_italic_' and '*italic*' will conceal to just _italic_. Similarly '__bold__',
-'**bold**', '___italic bold___', and '***italic bold***' will conceal to just
-**bold**, **bold**, **_italic bold_**, and **_italic bold_** respectively.
+  Concealing is set for some syntax.
 
-To enable conceal use Vim's standard conceal configuration.
+  For example, conceal '[link text](link url)' as just 'link text'. Also,
+  '_italic_' and '*italic*' will conceal to just _italic_. Similarly
+  '__bold__', '**bold**', '___italic bold___', and '***italic bold***' will
+  conceal to just **bold**, **bold**, **_italic bold_**, and **_italic
+  bold_** respectively.
+
+  To enable conceal use Vim's standard conceal configuration.
 >
   set conceallevel=2
 <
-To disable conceal regardless of 'conceallevel' setting, add the following to
-your '.vimrc':
+  To disable conceal regardless of 'conceallevel' setting, add the following
+  to your '.vimrc':
 >
   let g:vim_markdown_conceal = 0
 <
-To disable math conceal with LaTeX math syntax enabled, add the following to
-your '.vimrc':
+  To disable math conceal with LaTeX math syntax enabled, add the following
+  to your '.vimrc':
 >
   let g:tex_conceal = ""
   let g:vim_markdown_math = 1
 <
 -------------------------------------------------------------------------------
                                      *vim-markdown-fenced-code-block-languages*
-                                              *g:vim_markdown_fenced_languages*
 Fenced code block languages ~
 
-You can use filetype name as fenced code block languages for syntax
-highlighting. If you want to use different name from filetype, you can add it
-in your '.vimrc' like so:
+                                              *g:vim_markdown_fenced_languages*
+- 'g:vim_markdown_fenced_languages'
+
+  You can use filetype name as fenced code block languages for syntax
+  highlighting. If you want to use different name from filetype, you can add
+  it in your '.vimrc' like so:
 >
   let g:vim_markdown_fenced_languages = ['csharp=cs']
 <
-This will cause the following to be highlighted using the 'cs' filetype syntax.
+  This will cause the following to be highlighted using the 'cs' filetype
+  syntax.
 >
   ```csharp
   ...
   ```
 <
-Default is "['c++=cpp', 'viml=vim', 'bash=sh', 'ini=dosini']".
+  Default is "['c++=cpp', 'viml=vim', 'bash=sh', 'ini=dosini']".
 
 -------------------------------------------------------------------------------
                                             *vim-markdown-follow-named-anchors*
-                                                 *g:vim_markdown_follow_anchor*
-                                                    *g:vim_markdown_anchorexpr*
 Follow named anchors ~
 
-This feature allows the 'ge' command to follow named anchors in links of the
-form 'file#anchor' or just '#anchor', where file may omit the '.md' extension
-as usual. Two variables control its operation:
+                                                 *g:vim_markdown_follow_anchor*
+- 'g:vim_markdown_follow_anchor'
+
+  This feature allows the 'ge' command to follow named anchors in links of
+  the form 'file#anchor' or just '#anchor', where file may omit the '.md'
+  extension as usual. Two variables control its operation:
 >
   let g:vim_markdown_follow_anchor = 1
 <
-This tells vim-markdown whether to attempt to follow a named anchor in a link
-or not. When it is 1, and only if a link can be split in two parts by the
-pattern '#', then the first part is interpreted as the file and the second one
-as the named anchor. This also includes urls of the form '#anchor', for which
-the first part is considered empty, meaning that the target file is the current
-one. After the file is opened, the anchor will be searched.
+  This tells vim-markdown whether to attempt to follow a named anchor in a
+  link or not. When it is 1, and only if a link can be split in two parts by
+  the pattern '#', then the first part is interpreted as the file and the
+  second one as the named anchor. This also includes urls of the form
+  '#anchor', for which the first part is considered empty, meaning that the
+  target file is the current one. After the file is opened, the anchor will
+  be searched.
 
-Default is '0'.
+  Default is '0'.
+
+                                                    *g:vim_markdown_anchorexpr*
+- 'g:vim_markdown_anchorexpr'
 >
   let g:vim_markdown_anchorexpr = "'<<'.v:anchor.'>>'"
 <
-This expression will be evaluated substituting 'v:anchor' with a quoted string
-that contains the anchor to visit. The result of the evaluation will become the
-real anchor to search in the target file. This is useful in order to convert
-anchors of the form, say, 'my-section-title' to searches of the form 'My
-Section Title' or '<<my-section-title>>'.
+  This expression will be evaluated substituting 'v:anchor' with a quoted
+  string that contains the anchor to visit. The result of the evaluation will
+  become the real anchor to search in the target file. This is useful in
+  order to convert anchors of the form, say, 'my-section-title' to searches
+  of the form 'My Section Title' or '<<my-section-title>>'.
 
-Default is "''".
+  Default is "''".
 
 -------------------------------------------------------------------------------
                                                *vim-markdown-syntax-extensions*
@@ -296,136 +324,161 @@ are off by default.
 
 -------------------------------------------------------------------------------
                                                       *vim-markdown-latex-math*
-                                                          *g:vim_markdown_math*
 LaTeX math ~
 
-Used as '$x^2$', '$$x^2$$', escapable as '\$x\$' and '\$\$x\$\$'.
+                                                          *g:vim_markdown_math*
+- 'g:vim_markdown_math'
+
+  Used as '$x^2$', '$$x^2$$', escapable as '\$x\$' and '\$\$x\$\$'.
 >
   let g:vim_markdown_math = 1
 <
 -------------------------------------------------------------------------------
                                                *vim-markdown-yaml-front-matter*
-                                                   *g:vim_markdown_frontmatter*
 YAML Front Matter ~
 
-Highlight YAML front matter as used by Jekyll or Hugo [7].
+                                                   *g:vim_markdown_frontmatter*
+- 'g:vim_markdown_frontmatter'
+
+  Highlight YAML front matter as used by Jekyll or Hugo [7].
 >
   let g:vim_markdown_frontmatter = 1
 <
 -------------------------------------------------------------------------------
                                                *vim-markdown-toml-front-matter*
-                                              *g:vim_markdown_toml_frontmatter*
 TOML Front Matter ~
 
-Highlight TOML front matter as used by Hugo [7].
+                                              *g:vim_markdown_toml_frontmatter*
+- 'g:vim_markdown_toml_frontmatter'
 
-TOML syntax highlight requires vim-toml [8].
+  Highlight TOML front matter as used by Hugo [7].
+
+  TOML syntax highlight requires vim-toml [8].
 >
   let g:vim_markdown_toml_frontmatter = 1
 <
 -------------------------------------------------------------------------------
                                                *vim-markdown-json-front-matter*
-                                              *g:vim_markdown_json_frontmatter*
 JSON Front Matter ~
 
-Highlight JSON front matter as used by Hugo [7].
+                                              *g:vim_markdown_json_frontmatter*
+- 'g:vim_markdown_json_frontmatter'
 
-JSON syntax highlight requires vim-json [9].
+  Highlight JSON front matter as used by Hugo [7].
+
+  JSON syntax highlight requires vim-json [9].
 >
   let g:vim_markdown_json_frontmatter = 1
 <
 -------------------------------------------------------------------------------
                                                    *vim-markdown-strikethrough*
-                                                 *g:vim_markdown_strikethrough*
 Strikethrough ~
 
-Strikethrough uses two tildes. '~~Scratch this.~~'
+                                                 *g:vim_markdown_strikethrough*
+- 'g:vim_markdown_strikethrough'
+
+  Strikethrough uses two tildes. '~~Scratch this.~~'
 >
   let g:vim_markdown_strikethrough = 1
 <
 -------------------------------------------------------------------------------
                                      *vim-markdown-adjust-new-list-item-indent*
-                                          *g:vim_markdown_new_list_item_indent*
 Adjust new list item indent ~
 
-You can adjust a new list indent. For example, you insert a single line like
-below:
+                                          *g:vim_markdown_new_list_item_indent*
+- 'g:vim_markdown_new_list_item_indent'
+
+  You can adjust a new list indent. For example, you insert a single line
+  like below:
 >
   * item1
 <
-Then if you type 'o' to insert new line in vim and type '* item2', the result
-will be:
+  Then if you type 'o' to insert new line in vim and type '* item2', the
+  result will be:
 >
   * item1
       * item2
 <
-vim-markdown automatically insert the indent. By default, the number of spaces
-of indent is 4. If you'd like to change the number as 2, just write:
+  vim-markdown automatically insert the indent. By default, the number of
+  spaces of indent is 4. If you'd like to change the number as 2, just write:
 >
   let g:vim_markdown_new_list_item_indent = 2
 <
 -------------------------------------------------------------------------------
                 *vim-markdown-do-not-require-.md-extensions-for-markdown-links*
-                                     *g:vim_markdown_no_extensions_in_markdown*
 Do not require .md extensions for Markdown links ~
 
-If you want to have a link like this '[link text](link-url)' and follow it for
-editing in vim using the 'ge' command, but have it open the file "link-url.md"
-instead of the file "link-url", then use this option:
+                                     *g:vim_markdown_no_extensions_in_markdown*
+- 'g:vim_markdown_no_extensions_in_markdown'
+
+  If you want to have a link like this '[link text](link-url)' and follow it
+  for editing in vim using the 'ge' command, but have it open the file "link-
+  url.md" instead of the file "link-url", then use this option:
 >
   let g:vim_markdown_no_extensions_in_markdown = 1
 <
-This is super useful for GitLab and GitHub wiki repositories.
+  This is super useful for GitLab and GitHub wiki repositories.
 
-Normal behaviour would be that vim-markup required you to do this '[link text
-](link-url.md)', but this is not how the Gitlab and GitHub wiki repositories
-work. So this option adds some consistency between the two.
+  Normal behaviour would be that vim-markup required you to do this '[link
+  text](link-url.md)', but this is not how the Gitlab and GitHub wiki
+  repositories work. So this option adds some consistency between the two.
 
 -------------------------------------------------------------------------------
                                   *vim-markdown-auto-write-when-following-link*
-                                                     *g:vim_markdown_autowrite*
 Auto-write when following link ~
 
-If you follow a link like this '[link text](link-url)' using the 'ge' shortcut,
-this option will automatically save any edits you made before moving you:
+                                                     *g:vim_markdown_autowrite*
+- 'g:vim_markdown_autowrite'
+
+  If you follow a link like this '[link text](link-url)' using the 'ge'
+  shortcut, this option will automatically save any edits you made before
+  moving you:
 >
   let g:vim_markdown_autowrite = 1
 <
 -------------------------------------------------------------------------------
                                    *vim-markdown-change-default-file-extension*
-                                            *g:vim_markdown_auto_extension_ext*
 Change default file extension ~
 
-If you would like to use a file extension other than '.md' you may do so using
-the 'vim_markdown_auto_extension_ext' variable:
+                                            *g:vim_markdown_auto_extension_ext*
+- 'g:vim_markdown_auto_extension_ext'
+
+  If you would like to use a file extension other than '.md' you may do so
+  using the 'vim_markdown_auto_extension_ext' variable:
 >
   let g:vim_markdown_auto_extension_ext = 'txt'
 <
 -------------------------------------------------------------------------------
                         *vim-markdown-do-not-automatically-insert-bulletpoints*
-                                           *g:vim_markdown_auto_insert_bullets*
 Do not automatically insert bulletpoints ~
 
-Automatically inserting bulletpoints can lead to problems when wrapping text
-(see issue #232 for details), so it can be disabled:
+                                           *g:vim_markdown_auto_insert_bullets*
+- 'g:vim_markdown_auto_insert_bullets'
+
+  Automatically inserting bulletpoints can lead to problems when wrapping
+  text (see issue #232 for details), so it can be disabled:
 >
   let g:vim_markdown_auto_insert_bullets = 0
 <
-In that case, you probably also want to set the new list item indent to 0 as
-well, or you will have to remove an indent each time you add a new list item:
+  In that case, you probably also want to set the new list item indent to 0
+  as well, or you will have to remove an indent each time you add a new list
+  item:
 >
   let g:vim_markdown_new_list_item_indent = 0
 <
 -------------------------------------------------------------------------------
                                     *vim-markdown-change-how-to-open-new-files*
-                                                   *g:vim_markdown_edit_url_in*
 Change how to open new files ~
 
-By default when following a link the target file will be opened in your current
-buffer. This behavior can change if you prefer using splits or tabs by using
-the 'vim_markdown_edit_url_in' variable. Possible values are 'tab', 'vsplit',
-'hsplit', 'current' opening in a new tab, vertical split, horizontal split, and
-current buffer respectively. Defaults to current buffer if not set:
+                                                   *g:vim_markdown_edit_url_in*
+- 'g:vim_markdown_edit_url_in'
+
+  By default when following a link the target file will be opened in your
+  current buffer. This behavior can change if you prefer using splits or tabs
+  by using the 'vim_markdown_edit_url_in' variable. Possible values are
+  'tab', 'vsplit', 'hsplit', 'current' opening in a new tab, vertical split,
+  horizontal split, and current buffer respectively. Defaults to current
+  buffer if not set:
 >
   let g:vim_markdown_edit_url_in = 'tab'
 <


### PR DESCRIPTION
See https://github.com/plasticboy/vim-markdown/pull/429#issuecomment-485348064.

html2vimdoc doesn't handle code snippets surrounded with ` ``` ` under the list properly, so I replaced code snippets with indented ones.