### PR TITLE
document `conceal_code_blocks` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,13 @@ set conceallevel=2
 To disable conceal regardless of `conceallevel` setting, add the following to your `.vimrc`:
 
 ```vim
-let g:vim_markdown_conceal = 0
+let g:vim_markdown_conceal = 0 
+```
+
+Disabling conceal for code fences requires an additional setting:
+
+```vim
+let g:vim_markdown_conceal_code_blocks = 0
 ```
 
 To disable math conceal with LaTeX math syntax enabled, add the following to your `.vimrc`:


### PR DESCRIPTION
I set `conceallevel=0` in .vimrc, as well as `g:vim_markdown_conceal = 0` but code fences were still being hidden. I could not find this option documented anywhere, so I went to the source code. Adding the `g:vim_markdown_conceal_code_blocks = 0` fixed my problem, and I assume other people will want to find this in the future.