### PR TITLE
Fix mkdInlineURL not to highlight after closing brackets

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -70,10 +70,10 @@ execute 'syn region mkdLink matchgroup=mkdDelimiter  start="\\\@<!!\?\[\ze[^]\n]
 " Autolink without angle brackets.
 " mkd  inline links:      protocol     optional  user:pass@  sub/domain                    .com, .co.uk, etc         optional port   path/querystring/hash fragment
 "                         ------------ _____________________ ----------------------------- _________________________ ----------------- __
-syn match   mkdInlineURL /https\?:\/\/\(\w\+\(:\w\+\)\?@\)\?\([A-Za-z0-9][-_0-9A-Za-z]*\.\)\{1,}\(\w\{2,}\.\?\)\{1,}\(:[0-9]\{1,5}\)\?\S*/
+syn match   mkdInlineURL /https\?:\/\/\(\w\+\(:\w\+\)\?@\)\?\([A-Za-z0-9][-_0-9A-Za-z]*\.\)\{1,}\(\w\{2,}\.\?\)\{1,}\(:[0-9]\{1,5}\)\?[^] \t]*/
 
 " Autolink with parenthesis.
-syn region  mkdInlineURL matchgroup=mkdDelimiter start="(\(https\?:\/\/\(\w\+\(:\w\+\)\?@\)\?\([A-Za-z0-9][-_0-9A-Za-z]*\.\)\{1,}\(\w\{2,}\.\?\)\{1,}\(:[0-9]\{1,5}\)\?\S*)\)\@=" end=")"
+syn region  mkdInlineURL matchgroup=mkdDelimiter start="(\(https\?:\/\/\(\w\+\(:\w\+\)\?@\)\?\([A-Za-z0-9][-_0-9A-Za-z]*\.\)\{1,}\(\w\{2,}\.\?\)\{1,}\(:[0-9]\{1,5}\)\?[^] \t]*)\)\@=" end=")"
 
 " Autolink with angle brackets.
 syn region mkdInlineURL matchgroup=mkdDelimiter start="\\\@<!<\ze[a-z][a-z0-9,.-]\{1,22}:\/\/[^> ]*>" end=">"

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -634,7 +634,8 @@ Given markdown;
 
 Execute (link with url title):
   AssertEqual SyntaxOf('https://domain.tld'), 'mkdInlineURL'
-  AssertEqual SyntaxOf('https://domain.com'), 'mkdInlineURL'
+  AssertNotEqual SyntaxOf(']'), 'mkdInlineURL'
+  AssertEqual SyntaxOf('https://domain.com'), 'mkdURL'
   AssertNotEqual SyntaxOf('not_a_link'), 'mkdInlineURL'
 
 # Code Blocks


### PR DESCRIPTION
Fix #419.

This is a minimal change that replacing `\S*` with `[^] \t]*`, to stop `mkdInlineURL` consuming a `]` character.