### PR TITLE
Add `:InsertToc` and `:InsertNToc` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,12 @@ The following requires `:filetype plugin on`.
 
 -   `:Tocv`: Same as `:Toc` for symmetry with `:Toch` and `:Tocv`.
 
+-   `:InsertToc`: Insert table of contents at the current line.
+
+    An optional argument can be used to specify how many levels of headers to display in the table of content, e.g., to display up to and including `h3`, use `:InsertToc 3`.
+
+-   `:InsertNToc`: Same as `:InsertToc`, but the format of `h2` headers in the table of contents is a numbered list, rather than a bulleted list.
+
 ## Credits
 
 The main contributors of vim-markdown are:

--- a/test/folding-toc.vader
+++ b/test/folding-toc.vader
@@ -120,28 +120,28 @@ Execute (check TOC):
   let res = getloclist(0)
   let elem = res[0]
   AssertEqual elem.lnum, 1
-  AssertEqual elem.text, '# chap 1'
+  AssertEqual elem.text, 'chap 1'
   let elem = res[1]
   AssertEqual elem.lnum, 15
-  AssertEqual elem.text, '## chap 1.1'
+  AssertEqual elem.text, '  chap 1.1'
   let elem = res[2]
   AssertEqual elem.lnum, 25
-  AssertEqual elem.text, '### chap 1.1.1'
+  AssertEqual elem.text, '    chap 1.1.1'
   let elem = res[3]
   AssertEqual elem.lnum, 30
-  AssertEqual elem.text, '# chap 2'
+  AssertEqual elem.text, 'chap 2'
   let elem = res[4]
   AssertEqual elem.lnum, 34
-  AssertEqual elem.text, '## chap 2.1'
+  AssertEqual elem.text, '  chap 2.1'
   let elem = res[5]
   AssertEqual elem.lnum, 41
-  AssertEqual elem.text, '# chap 3'
+  AssertEqual elem.text, 'chap 3'
   let elem = res[6]
   AssertEqual elem.lnum, 45
   AssertEqual elem.text, 'chap 4'
   let elem = res[7]
   AssertEqual elem.lnum, 50
-  AssertEqual elem.text, 'chap 4.1'
+  AssertEqual elem.text, '  chap 4.1'
 
 Given markdown;
 ---
@@ -174,5 +174,5 @@ Execute (check Toc of yaml front matter):
   AssertEqual len(res), 1
   let elem = res[0]
   AssertEqual elem.lnum, 8
-  AssertEqual elem.text, 'heading'
+  AssertEqual elem.text, '  heading'
   unlet g:vim_markdown_frontmatter

--- a/test/insert-toc.vader
+++ b/test/insert-toc.vader
@@ -1,0 +1,147 @@
+Given markdown;
+# a
+
+## Foo Level 2
+
+### Foo Level 3
+
+#### Foo Level 4
+
+Bar Level 2
+-----------
+
+### Bar Level 3
+
+Execute (InsertToc format):
+  :2
+  :call append('.', '')
+  :InsertToc
+
+Expect (format):
+  # a
+
+  * [Foo Level 2](#foo-level-2)
+    * [Foo Level 3](#foo-level-3)
+      * [Foo Level 4](#foo-level-4)
+  * [Bar Level 2](#bar-level-2)
+    * [Bar Level 3](#bar-level-3)
+
+  ## Foo Level 2
+
+  ### Foo Level 3
+
+  #### Foo Level 4
+
+  Bar Level 2
+  -----------
+
+  ### Bar Level 3
+
+Given markdown;
+# a
+
+## Foo Level 2
+
+### Foo Level 3
+
+#### Foo Level 4
+
+Bar Level 2
+-----------
+
+### Bar Level 3
+
+Execute (InsertToc only h2 headers):
+  :2
+  :call append('.', '')
+  :InsertToc 2
+
+Expect (only h2 headers):
+  # a
+
+  * [Foo Level 2](#foo-level-2)
+  * [Bar Level 2](#bar-level-2)
+
+  ## Foo Level 2
+
+  ### Foo Level 3
+
+  #### Foo Level 4
+
+  Bar Level 2
+  -----------
+
+  ### Bar Level 3
+
+Given markdown;
+# a
+
+## Foo Level 2
+
+### Foo Level 3
+
+#### Foo Level 4
+
+Bar Level 2
+-----------
+
+## Baz Level 2
+
+## Foobar Level 2
+
+## Foobaz Level 2
+
+## Barfoo Level 2
+
+## Barbaz Level 2
+
+## Bazfoo Level 2
+
+## Bazbar Level 2
+
+## Foobarbaz Level 2
+
+Execute (InsertNToc format, and up to h3 headers):
+  :2
+  :call append('.', '')
+  :InsertNToc 3
+
+Expect (format, and up to h3 headers):
+  # a
+
+   1. [Foo Level 2](#foo-level-2)
+      * [Foo Level 3](#foo-level-3)
+   2. [Bar Level 2](#bar-level-2)
+   3. [Baz Level 2](#baz-level-2)
+   4. [Foobar Level 2](#foobar-level-2)
+   5. [Foobaz Level 2](#foobaz-level-2)
+   6. [Barfoo Level 2](#barfoo-level-2)
+   7. [Barbaz Level 2](#barbaz-level-2)
+   8. [Bazfoo Level 2](#bazfoo-level-2)
+   9. [Bazbar Level 2](#bazbar-level-2)
+  10. [Foobarbaz Level 2](#foobarbaz-level-2)
+
+  ## Foo Level 2
+
+  ### Foo Level 3
+
+  #### Foo Level 4
+
+  Bar Level 2
+  -----------
+
+  ## Baz Level 2
+
+  ## Foobar Level 2
+
+  ## Foobaz Level 2
+
+  ## Barfoo Level 2
+
+  ## Barbaz Level 2
+
+  ## Bazfoo Level 2
+
+  ## Bazbar Level 2
+
+  ## Foobarbaz Level 2


### PR DESCRIPTION
There wasn't any open issue for this feature request, but I thought of implementing it anyway, as I find it very useful. Hopefully other people find it useful as well.

The `:InsertToc` command inserts a table of contents at the current line in the markdown buffer. The `:InsertNToc` command behaves like `:InsertToc,` but the format of h2 headers in the table of contents is a numbered list, rather than a bulleted list.

An optional argument can be used to specify how many levels of headers to display in the table of content, e.g., to display up to and including h3, use `:InsertToc 3`.

![inserttoc-test](https://user-images.githubusercontent.com/24732205/75298626-502e2800-5833-11ea-99b2-8c847c059559.gif)

Documentation and unit tests added as well.