### PR TITLE
feat: Allow characters after code fence language

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -702,7 +702,8 @@ function! s:MarkdownHighlightSources(force)
     " Look for code blocks in the current file
     let filetypes = {}
     for line in getline(1, '$')
-        let ft = matchstr(line, '```\s*\zs[0-9A-Za-z_+-]*')
+        let ft = matchstr(line, '```\s*\zs[0-9A-Za-z_+-]*\ze.*')
+        echom ft
         if !empty(ft) && ft !~ '^\d*$' | let filetypes[ft] = 1 | endif
     endfor
     if !exists('b:mkd_known_filetypes')
@@ -733,7 +734,7 @@ function! s:MarkdownHighlightSources(force)
             else
                 let include = '@' . toupper(filetype)
             endif
-            let command = 'syntax region %s matchgroup=%s start="^\s*```\s*%s$" matchgroup=%s end="\s*```$" keepend contains=%s%s'
+            let command = 'syntax region %s matchgroup=%s start="^\s*```\s*%s.*$" matchgroup=%s end="\s*```$" keepend contains=%s%s'
             execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') && get(g:, 'vim_markdown_conceal', 1) && get(g:, 'vim_markdown_conceal_code_blocks', 1) ? ' concealends' : '')
             execute printf('syntax cluster mkdNonListItem add=%s', group)
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -739,12 +739,18 @@ def a
 end
 ```
 
+```ruby {linenos=table,hl_lines=[8,"15-17"],linenostart=199}
+class b
+end
+```
+
 Execute (fenced code block syntax with a language specifier):
   let b:func = Markdown_GetFunc('vim-markdown/ftplugin/markdown.vim', 'MarkdownRefreshSyntax')
   call b:func(0)
   AssertEqual SyntaxOf('include'), 'cInclude'
   AssertEqual SyntaxOf('code'), 'mkdSnippetCPP'
   AssertEqual SyntaxOf('def'), 'rubyDefine'
+  AssertEqual SyntaxOf('class'), 'rubyClass'
 
 Given markdown;
 ``` c++


### PR DESCRIPTION
 In Hugo, [code block fences can include extra options](https://gohugo.io/content-management/syntax-highlighting/#highlighting-in-code-fences) in them. This change allows these extra characters to be ignored such that the highlighting still works. ie.

    ```bash {linenos=table,hl_lines=[8,"15-17"],linenostart=199}
    #!/bin/bash
    ....
    ```
