### PR TITLE
fixup: Remove debugging echo message

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -703,7 +703,6 @@ function! s:MarkdownHighlightSources(force)
     let filetypes = {}
     for line in getline(1, '$')
         let ft = matchstr(line, '```\s*\zs[0-9A-Za-z_+-]*\ze.*')
-        echom ft
         if !empty(ft) && ft !~ '^\d*$' | let filetypes[ft] = 1 | endif
     endfor
     if !exists('b:mkd_known_filetypes')


### PR DESCRIPTION
Forgot to remove a `echom` debugging command from PR #492 

Thanks to @petobens for pointing it out.