### PR TITLE
mkd.vim: open URL (gx) based on mkdID/mkdLinkDef

### DIFF
--- a/doc/vim-markdown.txt
+++ b/doc/vim-markdown.txt
@@ -504,7 +504,16 @@ The following work on normal and visual modes:
   inside a link.
 
   For example, all the following cursor positions will work:
+
 >
+  [myexample]: http://example.com
+  ^  ^    ^ ^  ^       ^
+  1  2    3 4  5       6
+
+  [Example][myexample]
+  ^  ^    ^^   ^
+  1  2    34   5
+
   [Example](http://example.com)
   ^  ^    ^^   ^       ^
   1  2    34   5       6


### PR DESCRIPTION
This change lets `gx` open URLs when the cursor is on either `mkdID`, `mkdLinkDef` syntax regions. It also supports `mkdLink` region where the following syntax region is a `mkdID` and not an `mkdURL`.

* `FindNextSyntax` was repurposed for finding the next syntax object (whatever the name is). Then, we call repeatedly the function for getting where we want. Most of the time, we just need to call it twice or so.
* New functions `FindMkdLinkDefTargetPosition`, `GetUrlPositionFromMkdLink`, `GetUrlPositionFromMkdIDOrDef`: handle cases where we're presently looking at mkdLink, mkdID and mkdLinkDef.
* `Markdown_GetUrlForPosition`: the approach was slightly changed so that we first find out if we're on a delimiter, then move from there to the delimited region. Then, we handle other cases seperatly from the delimiters case. This makes for an approach that is more readable and easier to maintain.
* Doc was also updated to express the support for the new syntax regions.

This effectively fixes #382.

I don't know about people that expressed the issue #353, but the code seems to work OK before these changes according to the supported regions. May be the people from #353 will find a fix for their issue with this change if for some reason they didn't express their issue appropriately and that they were rather having an issue with `mkdID` and `mkdLinkDef` not working. This was by design and consistent with the doc. However, it would be clearly more intuitive for the user if my change was merged. I may be misinterpreting. In the latter case, the issue is orthogonal to my change anyway.