### PR TITLE
use strdisplaywidth when computing foldtext

### DIFF
--- a/after/ftplugin/markdown.vim
+++ b/after/ftplugin/markdown.vim
@@ -92,7 +92,7 @@ if get(g:, "vim_markdown_folding_style_pythonic", 0)
         let foldedlinecount = v:foldend - v:foldstart
         let line = strpart(line, 0, windowwidth - 2 -len(foldedlinecount))
         let line = substitute(line, '\%("""\|''''''\)', '', '')
-        let fillcharcount = windowwidth - len(line) - len(foldedlinecount) + 1
+        let fillcharcount = windowwidth - strdisplaywidth(line) - len(foldedlinecount) + 1
         return line . ' ' . repeat("-", fillcharcount) . ' ' . foldedlinecount
     endfunction
 else " vim_markdown_folding_style_pythonic == 0


### PR DESCRIPTION
Handle characters such that len(c)>2 and strdisplaywidth(c)=2.

**Current (buggy)** (with `g:vim_markdown_folding_style_pythonic == 1`)
![image](https://user-images.githubusercontent.com/19489738/91982074-b062d100-ed64-11ea-94a4-a79f96fc7abe.png)
On line 15, I typed two Korean characters whose `len` is 3 and `strdisplaywidth` is 2. As a result, the fold text for that line is 2 characters off.

**Fixed**
![image](https://user-images.githubusercontent.com/19489738/91982020-9d500100-ed64-11ea-8624-3b4a36ce44ee.png)
With this patch, the line counts are now properly alligned.