### PR TITLE
Use ^\s*```$ for mkdCodeEnd

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -819,7 +819,7 @@ function! s:MarkdownHighlightSources(force)
             else
                 let include = '@' . toupper(filetype)
             endif
-            let command = 'syntax region %s matchgroup=%s start="^\s*```\s*%s.*$" matchgroup=%s end="\s*```$" keepend contains=%s%s'
+            let command = 'syntax region %s matchgroup=%s start="^\s*```\s*%s.*$" matchgroup=%s end="^\s*```$" keepend contains=%s%s'
             execute printf(command, group, startgroup, ft, endgroup, include, has('conceal') && get(g:, 'vim_markdown_conceal', 1) && get(g:, 'vim_markdown_conceal_code_blocks', 1) ? ' concealends' : '')
             execute printf('syntax cluster mkdNonListItem add=%s', group)
 


### PR DESCRIPTION
Some languages use markdown style fenced code block for documenting examples. Current pattern for mkdCodeEnd breaks that.

Current:
![image](https://user-images.githubusercontent.com/19489738/94511383-17848000-0254-11eb-9393-2f1e10b345ad.png)

Fixed:
![image](https://user-images.githubusercontent.com/19489738/94511392-1e12f780-0254-11eb-9261-f27dbf2ccb09.png)
