### PR TITLE
Allow getting markdown header

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Syntax highlighting, matching rules and mappings for [the original Markdown](htt
 1. [Options](#options)
 1. [Mappings](#mappings)
 1. [Commands](#commands)
+1. [Functions](#commands)
 1. [Credits](#credits)
 1. [License](#license)
 
@@ -446,6 +447,15 @@ The main contributors of vim-markdown are:
 - **Ben Williams** (A.K.A. **plasticboy**). The original developer of vim-markdown. [Homepage](http://plasticboy.com/).
 
 If you feel that your name should be on this list, please make a pull request listing your contributions.
+
+## Functions
+
+-   `g:MarkdownGetHeader`:
+
+    Returns the full, current header line. Useful to add to statusline, for example if using [airline](https://github.com/vim-airline/vim-airline)
+```
+let g:airline_section_gutter = '%= %{exists(''*MarkdownGetHeader'')?MarkdownGetHeader():""}'
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Syntax highlighting, matching rules and mappings for [the original Markdown](htt
 1. [Options](#options)
 1. [Mappings](#mappings)
 1. [Commands](#commands)
-1. [Functions](#commands)
+1. [Functions](#functions)
 1. [Credits](#credits)
 1. [License](#license)
 

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -63,6 +63,14 @@ let s:levelRegexpDict = {
 "
 let s:headersRegexp = '\v^(#|.+\n(\=+|-+)$)'
 
+
+" Returns full header line if there is one
+"
+function! g:MarkdownGetHeader()
+  return getline(s:GetHeaderLineNum())
+endfunction
+
+
 " Returns the line number of the first header before `line`, called the
 " current header.
 "


### PR DESCRIPTION
This MarkdownGetHeader() function is useful for adding the section of markdown you're currently in by seeing it in the status bar, eg with airline:
```
let g:airline_section_gutter = '%= %#hdrinfo#%{exists(''*MarkdownGetHeader'')?MarkdownGetHeader()[0:20]:""}'
```