### PR TITLE
supporting relative path for EditUrlUnderCursor

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -665,9 +665,16 @@ function! s:CreateFilePath(filepath, extension)
   let l:filepath = substitute(a:filepath, '^./', '', '')
   let l:current_path_list = split(expand('%:p:h'), '/', 1)
   let l:file_path_list = split(l:filepath, '/', 1)
-  let l:backs = len(matchfuzzy(l:file_path_list, '..'))
-  let l:new_path = l:current_path_list[:-l:backs-1]
-  let l:trail = '/'.join(l:file_path_list[l:backs:], '/').a:extension
+  let l:backs_count = 0
+  "whole for block can be replaced with matchfuzzy if it is supported
+  for i in l:file_path_list
+    if i == '..'
+      let l:backs_count += 1
+    endif
+  endfor
+  "let l:backs = len(matchfuzzy(l:file_path_list, '..'))
+  let l:new_path = l:current_path_list[:-l:backs_count-1]
+  let l:trail = '/'.join(l:file_path_list[l:backs_count:], '/').a:extension
   return fnameescape(join(l:new_path, '/').l:trail)
 endfunction
 

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -660,6 +660,16 @@ function! s:OpenUrlUnderCursor()
     endif
 endfunction
 
+" More general way of creating file path
+function! s:CreateFilePath(filepath, extension)
+  let l:current_path_list = split(expand('%:p:h'), '/', 1)
+  let l:file_path_list = split(a:filepath, '/', 1)
+  let l:backs = len(matchfuzzy(l:file_path_list, '..'))
+  let l:new_path = l:current_path_list[:-l:backs-1]
+  let l:trail = '/'.join(l:file_path_list[l:backs:], '/').a:extension
+  return fnameescape(join(l:new_path, '/').l:trail)
+endfunction
+
 " We need a definition guard because we invoke 'edit' which will reload this
 " script while this function is running. We must not replace it.
 if !exists('*s:EditUrlUnderCursor')
@@ -692,7 +702,7 @@ if !exists('*s:EditUrlUnderCursor')
                         let l:ext = '.md'
                     endif
                 endif
-                let l:url = fnameescape(fnamemodify(expand('%:h').'/'.l:url.l:ext, ':.'))
+                let l:url = s:CreateFilePath(l:url, l:ext)
                 let l:editmethod = ''
                 " determine how to open the linked file (split, tab, etc)
                 if exists('g:vim_markdown_edit_url_in')

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -662,8 +662,9 @@ endfunction
 
 " More general way of creating file path
 function! s:CreateFilePath(filepath, extension)
+  let l:filepath = substitute(a:filepath, '^./', '', '')
   let l:current_path_list = split(expand('%:p:h'), '/', 1)
-  let l:file_path_list = split(a:filepath, '/', 1)
+  let l:file_path_list = split(l:filepath, '/', 1)
   let l:backs = len(matchfuzzy(l:file_path_list, '..'))
   let l:new_path = l:current_path_list[:-l:backs-1]
   let l:trail = '/'.join(l:file_path_list[l:backs:], '/').a:extension


### PR DESCRIPTION
Hi,
I'm not sure this would be useful for anyone else but it helped me a lot.
I keep a rather complex structure for some of markdown projects so if you want to refer to a file or an anchor in a file in a sibling or a child directory, this patch makes it possible.

Supports patterns like `../sibling_dir/file#anchor` and `./child_dir/file#anchor` relative to the current buffer.

it's particularly useful  `g:vim_markdown_no_extensions_in_markdown` and `g:vim_markdown_follow_anchor` are set.