### PR TITLE
Add option to only recognize Atx headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Try `:help concealcursor` and `:help conceallevel` for details.
         :let g:vim_markdown_folding_level = 1
         :edit
 
+### Only recognize Atx headers
+
+-   `g:vim_markdown_atx_only`
+
+    To cause vim_markdown to only recognize Atx-style markdown headers during movement commands, add the following line to your `.vimrc`: 
+
+        let g:vim_markdown_atx_only = 1
+
 ### Disable Default Key Mappings
 
 -   `g:vim_markdown_no_default_key_mappings`

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -47,21 +47,34 @@
 
 " For each level, contains the regexp that matches at that level only.
 "
-let s:levelRegexpDict = {
-    \ 1: '\v^(#[^#]@=|.+\n\=+$)',
-    \ 2: '\v^(##[^#]@=|.+\n-+$)',
-    \ 3: '\v^###[^#]@=',
-    \ 4: '\v^####[^#]@=',
-    \ 5: '\v^#####[^#]@=',
-    \ 6: '\v^######[^#]@='
-\ }
 
 " Maches any header level of any type.
 "
 " This could be deduced from `s:levelRegexpDict`, but it is more
 " efficient to have a single regexp for this.
 "
-let s:headersRegexp = '\v^(#|.+\n(\=+|-+)$)'
+let s:vim_markdown_atx_only = get(g:, "vim_markdown_atx_only", 0)
+if s:vim_markdown_atx_only == 1
+    let s:headersRegexp = '^#'
+    let s:levelRegexpDict = {
+        \ 1: '\v^#[^#]@=',
+        \ 2: '\v^##[^#]@=',
+        \ 3: '\v^###[^#]@=',
+        \ 4: '\v^####[^#]@=',
+        \ 5: '\v^#####[^#]@=',
+        \ 6: '\v^######[^#]@='
+    \ }
+else
+    let s:headersRegexp = '\v^(#|.+\n(\=+|-+)$)'
+    let s:levelRegexpDict = {
+        \ 1: '\v^(#[^#]@=|.+\n\=+$)',
+        \ 2: '\v^(##[^#]@=|.+\n-+$)',
+        \ 3: '\v^###[^#]@=',
+        \ 4: '\v^####[^#]@=',
+        \ 5: '\v^#####[^#]@=',
+        \ 6: '\v^######[^#]@='
+    \ }
+endif
 
 " Returns the line number of the first header before `line`, called the
 " current header.


### PR DESCRIPTION
If the global variable vim_markdown_atx_only is set == 1,
only recognize Atx-style headers (leading #s) in movements;
otherwise, use previous behavior.